### PR TITLE
[exporter] The root transform should be at origin and rotation identity

### DIFF
--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -1906,8 +1906,8 @@ namespace com.github.hkrn
         public string Export(Stream stream)
         {
             var rootTransform = _gameObject.transform;
-            var translation = rootTransform.localPosition.ToVector3WithCoordinateSpace();
-            var rotation = rootTransform.localRotation.ToQuaternionWithCoordinateSpace();
+            var translation = System.Numerics.Vector3.Zero;
+            var rotation = System.Numerics.Quaternion.Identity;
             var scale = rootTransform.localScale.ToVector3();
             var rootNode = new gltf.node.Node
             {


### PR DESCRIPTION
## Summary

Set the position and rotation of the exported VRM root node to zero.

## Details

Currently, the transform information of the root node is copied as is. However, in VRM, anything other than scale is unnecessary and may even cause unintended issues. Additionally, since handling multiple avatars was not taken into account, at the very least, the position must be set to zero. There is essentially no reason to retain rotation in the root node, and the disadvantages outweigh the benefits, so it will also be set to zero. Scale, on the other hand, is needed in certain situations, so it will not be set to zero and will be retained.
