### PR TITLE
[chore] change link `vcc://` to https://hkrn.github.io/vpm.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ NDMF VRM Exporter には以下の特徴を持っています。
 
 ## 導入方法
 
-まず [VRChat Creator Companion](https://vcc.docs.vrchat.com) または [ALCOM](https://vrc-get.anatawa12.com/alcom/) を事前にインストールします。その後 [レポジトリ追加のリンク](vcc://vpm/addRepo?url=https%3A%2F%2Fhkrn.github.io%2Fvpm.json) をクリックしてレポジトリを導入します。手動で登録する場合は `https://hkrn.github.io/vpm.json` を指定します。
+まず [VRChat Creator Companion](https://vcc.docs.vrchat.com) または [ALCOM](https://vrc-get.anatawa12.com/alcom/) を事前にインストールします。その後 [レポジトリ追加のリンク](https://hkrn.github.io/vpm.html) をクリックしてレポジトリを導入します。手動で登録する場合は `https://hkrn.github.io/vpm.json` を指定します。
 
 レポジトリ導入後は `NDMF VRM Exporter` を検索してインストールすることで利用可能になります。
 


### PR DESCRIPTION
## Summary

Changes link of `vcc://` to https://hkrn.github.io/vpm.html

## Details

Fixes #6 