### PR TITLE
BlendShape の変形が正しく行われない問題を修正

### DIFF
--- a/Editor/Document.cs
+++ b/Editor/Document.cs
@@ -2158,13 +2158,13 @@ namespace com.github.hkrn.gltf
                         ? $"{name.Value}_{indexBufferViewSuffix}"
                         : indexBufferViewSuffix),
                 };
-                var componentType = builder.BaseAccessorCount switch
+                var (indices, values) = builder.Build();
+                var componentType = indices.Max() switch
                 {
                     > ushort.MaxValue => accessor.ComponentType.UnsignedInt,
                     > byte.MaxValue => accessor.ComponentType.UnsignedShort,
                     _ => accessor.ComponentType.UnsignedByte
                 };
-                var (indices, values) = builder.Build();
                 {
                     using MemoryStream memoryStream = new();
                     using BinaryWriter byteArray = new(memoryStream);
@@ -2174,7 +2174,7 @@ namespace com.github.hkrn.gltf
                         {
                             case accessor.ComponentType.UnsignedByte:
                             {
-                                byteArray.Write(BitConverter.GetBytes((byte)index));
+                                byteArray.Write((byte)index);
                                 break;
                             }
                             case accessor.ComponentType.UnsignedShort:

--- a/Editor/Document.cs
+++ b/Editor/Document.cs
@@ -2159,7 +2159,7 @@ namespace com.github.hkrn.gltf
                         : indexBufferViewSuffix),
                 };
                 var (indices, values) = builder.Build();
-                var componentType = indices.Max() switch
+                var componentType = indices.Last() switch
                 {
                     > ushort.MaxValue => accessor.ComponentType.UnsignedInt,
                     > byte.MaxValue => accessor.ComponentType.UnsignedShort,


### PR DESCRIPTION
## 変更内容
1. `componentType` が `UnsignedByte` の場合、`byteArray.Write()`で書き込むインデックスを `BitConverter.GetBytes((byte)index)` から `(byte)index` に変更し、1 バイトのデータが正しく書き込まれるように修正しました。  
2. `componentType` の判定基準を、`builder.BaseAccessorCount` ではなく、実際に使われているインデックス配列（`indices`）の最大値に基づいて決定するように変更しました。

## 変更理由
- 従来のコードでは、`BitConverter.GetBytes((byte)index)` が 2 バイトの配列を返していたため、BlendShape の頂点インデックスが正しく読み取れず、BlendShape の変形が崩れる問題が発生していました。1 バイトで書き込む処理に変更することで、不具合を解消します。  
- 従来のコードでは、 `builder.BaseAccessorCount` に基づいて `componentType` を判定していました。しかし実際には、`BuildMorphTarget()`で`CreateSparseAccessorVector3()`に渡される頂点インデックス (`positions`) は、「BlendShape で変位が 0 (すなわち頂点が変形しない)」と判断されたインデックスが除外されているため、インデックスの最大値が `builder.BaseAccessorCount` と一致しないケースが存在します。実際のインデックス値（`indices` の最大値）を元に判定することが正しいと判断しました。
