### PR TITLE
[exporter] fixes a bug #4 is not actually fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 ## [Unreleased]
 
+## [1.0.2] - 2025-01-30
+
+- [exporter] fixes a bug [#4](https://github.com/hkrn/ndmf-vrm-exporter/pull/4) is not actually fixed ([#15](https://github.com/hkrn/ndmf-vrm-exporter/pull/15))
+
 ## [1.0.1] - 2025-01-29
 
 ### Fixed
 
-- [exporter] fixes a bug `aixAxis` is not set properly (#5)
-- [exporter] fixes a bug `_CullMode` cannot retrieve properly on lilToon (#4)
-- [exporter] Inactive joint/constraint source transform should not be referred (#3)
-- [exporter] The root transform should be at origin and rotation identity (#2)
+- [exporter] fixes a bug `aixAxis` is not set properly ([#5](https://github.com/hkrn/ndmf-vrm-exporter/pull/5))
+- [exporter] fixes a bug `_CullMode` cannot retrieve properly on lilToon ([#4](https://github.com/hkrn/ndmf-vrm-exporter/pull/4))
+- [exporter] Inactive joint/constraint source transform should not be referred ([#3](https://github.com/hkrn/ndmf-vrm-exporter/pull/3))
+- [exporter] The root transform should be at origin and rotation identity ([#2](https://github.com/hkrn/ndmf-vrm-exporter/pull/2))
 
 ## [1.0.0] - 2025-01-23
 
@@ -17,6 +21,7 @@
 
 - Initial release
 
-[unreleased]: https://github.com/hkrn/ndmf-vrm-exporter/compare/1.0.1...HEAD
+[unreleased]: https://github.com/hkrn/ndmf-vrm-exporter/compare/1.0.2...HEAD
+[1.0.2]: https://github.com/hkrn/ndmf-vrm-exporter/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/hkrn/ndmf-vrm-exporter/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/hkrn/ndmf-vrm-exporter/releases/tag/1.0.0

--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -39,6 +39,7 @@ using Anatawa12.AvatarOptimizer.API;
 
 #if NVE_HAS_LILTOON
 using lilToon;
+using UnityEngine.Rendering;
 #endif // NVE_HAS_LILTOON
 
 #if NVE_HAS_NDMF
@@ -1812,6 +1813,7 @@ namespace com.github.hkrn
         private static readonly string VrmcSpringBoneExtendedCollider = "VRMC_springBone_extended_collider";
         private static readonly string VrmcNodeConstraint = "VRMC_node_constraint";
         private static readonly string VrmcMaterialsMtoon = "VRMC_materials_mtoon";
+        private static readonly int PropertyCull = Shader.PropertyToID("_Cull");
         private static readonly int PropertyUseEmission = Shader.PropertyToID("_UseEmission");
         private static readonly int PropertyUseBumpMap = Shader.PropertyToID("_UseBumpMap");
         private static readonly int PropertyAlphaMaskMode = Shader.PropertyToID("_AlphaMaskMode");
@@ -2505,7 +2507,9 @@ namespace com.github.hkrn
                             config.MainTexture = MaterialBaker.AutoBakeMainTexture(_assetSaver, m);
                         }
 
-                        config.CullMode = (int)m.GetFloat(GltfMaterialExporter.PropertyCullMode);
+                        config.CullMode = m.HasProperty(PropertyCull)
+                            ? (int)m.GetFloat(PropertyCull)
+                            : (int)CullMode.Back;
                         config.EnableEmission = Mathf.Approximately(m.GetFloat(PropertyUseEmission), 1.0f);
                         config.EnableNormalMap = Mathf.Approximately(m.GetFloat(PropertyUseBumpMap), 1.0f);
                         _bakedMaterialMainTextures.Add(m, config.MainTexture);
@@ -4348,7 +4352,7 @@ namespace com.github.hkrn
                 _extensionsUsed.Add(gltf.extensions.KhrTextureTransform.Name);
             }
 
-            internal static readonly int PropertyCullMode = Shader.PropertyToID("_CullMode");
+            private static readonly int PropertyCullMode = Shader.PropertyToID("_CullMode");
             private static readonly int PropertyColor = Shader.PropertyToID("_Color");
             private static readonly int PropertyMainTex = Shader.PropertyToID("_MainTex");
             private static readonly int PropertyEmissionColor = Shader.PropertyToID("_EmissionColor");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.github.hkrn.ndmf-vrm-exporter",
   "displayName": "NDMF VRM Exporter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "unity": "2022.3",
   "description": "NDMF Plugin to export the avatar as VRM 1.0 model.",
   "author": {


### PR DESCRIPTION
## Summary

This PR fixes a bug #4 is not actually fixed

## Details

Initially, I intended to fix this in #4, but the shader property that needed to be checked was different. After reviewing lilToon's implementation, it turned out that `_Cull` should be used instead. This has been corrected accordingly.

Since the fix in version 1.0.1 introduced another bug, I'll be releasing an urgent update.