### PR TITLE
[export] overhaul of texture processing

### DIFF
--- a/Editor/Resources.meta
+++ b/Editor/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d5227bf4ed734f8182a0dec36b7cb63
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Resources/MetalGlossChannelSwap.shader
+++ b/Editor/Resources/MetalGlossChannelSwap.shader
@@ -1,0 +1,64 @@
+﻿Shader "Hidden/MetalGlossChannelSwap"
+{
+	Properties
+	{
+		_MainTex ("Texture", 2D) = "white" {}
+		_SmoothnessMultiplier ("Smoothness Multiplier", float) = 1
+	}
+	SubShader
+	{
+		// No culling or depth
+		Cull Off ZWrite Off ZTest Always
+
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			
+			#include "UnityCG.cginc"
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			struct v2f
+			{
+				float2 uv : TEXCOORD0;
+				float4 vertex : SV_POSITION;
+			};
+
+			v2f vert (appdata v)
+			{
+				v2f o;
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.uv = v.uv;
+				return o;
+			}
+			
+			sampler2D _MainTex;
+			float _SmoothnessMultiplier;
+
+			float4 frag (v2f i) : SV_Target
+			{
+				float4 col = tex2D(_MainTex, i.uv);
+				// From the GLTF 2.0 spec
+				// The metallic-roughness texture. The metalness values are sampled from the B channel. 
+				// The roughness values are sampled from the G channel. These values are linear. 
+				// If other channels are present (R or A), they are ignored for metallic-roughness calculations.
+				//
+				// Unity, by default, puts metallic in R channel and glossiness in A channel.
+				// Unity uses a metallic-gloss texture so we need to invert the value in the g channel.
+				//
+				// Conversion Summary
+				// Unity R channel goes into B channel
+				// Unity A channel goes into G channel, then inverted
+				float4 result = float4(0, 1 - (col.a * _SmoothnessMultiplier), col.r, 1);
+				return result;
+			}
+			ENDCG
+		}
+	}
+}

--- a/Editor/Resources/MetalGlossChannelSwap.shader.meta
+++ b/Editor/Resources/MetalGlossChannelSwap.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d350f1754ec23422fab79bc2aefd25c6
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Resources/MetalGlossOcclusionChannelSwap.shader
+++ b/Editor/Resources/MetalGlossOcclusionChannelSwap.shader
@@ -1,0 +1,65 @@
+﻿Shader "Hidden/MetalGlossOcclusionChannelSwap"
+{
+	Properties
+	{
+		_MainTex ("Texture", 2D) = "white" {}
+		_SmoothnessMultiplier ("Smoothness Multiplier", float) = 1
+	}
+	SubShader
+	{
+		// No culling or depth
+		Cull Off ZWrite Off ZTest Always
+
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			
+			#include "UnityCG.cginc"
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			struct v2f
+			{
+				float2 uv : TEXCOORD0;
+				float4 vertex : SV_POSITION;
+			};
+
+			v2f vert (appdata v)
+			{
+				v2f o;
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.uv = v.uv;
+				return o;
+			}
+			
+			sampler2D _MainTex;
+			float _SmoothnessMultiplier;
+
+			float4 frag (v2f i) : SV_Target
+			{
+				float4 col = tex2D(_MainTex, i.uv);
+				// From the GLTF 2.0 spec
+				// The metallic-roughness texture. The metalness values are sampled from the B channel. 
+				// The roughness values are sampled from the G channel. These values are linear. 
+				// If other channels are present (R or A), they are ignored for metallic-roughness calculations.
+				//
+				// Unity, by default, puts metallic in R channel and glossiness in A channel.
+				// Unity uses a metallic-gloss texture so we need to invert the value in the g channel.
+				//
+				// Conversion Summary
+				// Unity R channel goes into B channel
+				// Unity A channel goes into G channel, then inverted
+				// Unity G channel goes into R channel > Occlusion
+				float4 result = float4(col.g, 1 - (col.a * _SmoothnessMultiplier), col.r, 1);
+				return result;
+			}
+			ENDCG
+		}
+	}
+}

--- a/Editor/Resources/MetalGlossOcclusionChannelSwap.shader.meta
+++ b/Editor/Resources/MetalGlossOcclusionChannelSwap.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f3f9683942e8844dda0792c0c4e1d59c
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Resources/NormalChannel.shader
+++ b/Editor/Resources/NormalChannel.shader
@@ -1,0 +1,66 @@
+﻿Shader "Hidden/NormalChannel"
+{
+	Properties
+	{
+		_MainTex ("Texture", 2D) = "white" {}
+	}
+	SubShader
+	{
+		// No culling or depth
+		Cull Off ZWrite Off ZTest Always
+
+		Pass
+		{
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#include "UnityCG.cginc"
+
+			struct appdata
+			{
+				float4 vertex : POSITION;
+				float2 uv : TEXCOORD0;
+			};
+
+			struct v2f
+			{
+				float2 uv : TEXCOORD0;
+				float4 vertex : SV_POSITION;
+			};
+
+			v2f vert (appdata v)
+			{
+				v2f o;
+				o.vertex = UnityObjectToClipPos(v.vertex);
+				o.uv = v.uv;
+				return o;
+			}
+
+			sampler2D _MainTex;
+
+			// fixed4 frag (v2f i) : SV_Target
+			// {
+			// 	float4 col = tex2D(_MainTex, i.uv);
+			// 	float4 res = float4(col.a, col.g, 1, 1);
+			// 	//res = float4(0.5,0.5,1,1);
+			// 	//res.xyz = GammaToLinearSpaceExact(res.xyz);
+			// 	// If a texture is marked as a normal map
+			// 	// the values are stored in the A and G channel.
+			// 	return res;
+			// }
+			
+			float4 frag (v2f i) : SV_Target
+			{
+				float4 col = tex2D(_MainTex, i.uv);
+				// If a texture is marked as a normal map
+				// the values are stored in the A and G channel.
+				float3 unpacked = UnpackNormal(col);
+				float4 result = float4(unpacked * 0.5f + 0.5f, 1);
+				return result;
+			}
+
+			ENDCG
+		}
+	}
+}

--- a/Editor/Resources/NormalChannel.shader.meta
+++ b/Editor/Resources/NormalChannel.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 7ec27eae8a1d84a0ca75d7a64d5e2e58
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Resources/README.md
+++ b/Editor/Resources/README.md
@@ -1,0 +1,5 @@
+Following shaders same as https://github.com/KhronosGroup/UnityGLTF/tree/release/2.14.1/Runtime/Resources
+
+* `MetalGlossChannelSwap.shader`
+* `MetalGlossOcclusionChannelSwap.shader`
+* `NormalChannel.shader`

--- a/Editor/Resources/README.md.meta
+++ b/Editor/Resources/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 518d2111b2b2b403dabb720bb7749518
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

This PR  overhauls of texture processing

## Details

### 1. Standardizing output to RGBA32 textures
Initially, to reduce texture size, RGBA32 was used when an alpha channel was needed, while RGB24 was used when it was not. However, the added complexity outweighed the benefits, so all texture output has been unified to RGBA32. According to the glTF specification, unused channels are simply ignored, so this change does not cause any issues.

### 2. Aligning texture storage with glTF
Previously, normal maps, metallic roughness textures, and occlusion textures were stored as is, without addressing the differences in storage methods between Unity and glTF. This has been corrected to match glTF’s format using the same approach as UnityGLTF.