### PR TITLE
[CI] allow to use `pull_request_target` except `.github`

### DIFF
--- a/.github/workflows/gameci.yml
+++ b/.github/workflows/gameci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths: [".github/**"]
+  pull_request_target:
+    branches: [main]
+    paths-ignore: [".github/**"]
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

This PR allows to use `pull_request_target` except `.github` directory.

## Details

This is implemented to address the issue where the CI for #14 cannot be executed.