### PR TITLE
[exporter] fix a bug where `WriteStream` was called twice

### DIFF
--- a/.github/workflows/gameci.yml
+++ b/.github/workflows/gameci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: Library
-          key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**', 'Tests/**') }}
+          key: Library-unity-2022.3.22f1
           restore-keys: |
             Library-
       - name: Run all tests

--- a/.github/workflows/gameci.yml
+++ b/.github/workflows/gameci.yml
@@ -22,6 +22,8 @@ jobs:
     permissions:
       contents: read
       checks: write
+    env:
+      UNITY_VERSION: 2022.3.22f1
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -40,9 +42,9 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: Library
-          key: Library-unity-2022.3.22f1
+          key: Library-unity-${{ env.UNITY_VERSION }}
           restore-keys: |
-            Library-
+            Library-unity-${{ env.UNITY_VERSION }}
       - name: Run all tests
         uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4.3.1
         env:
@@ -52,7 +54,7 @@ jobs:
         with:
           testMode: EditMode
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          unityVersion: 2022.3.22f1
+          unityVersion: ${{ env.UNITY_VERSION }}
       - name: Uploads test run result
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: always()

--- a/Editor/Document.cs
+++ b/Editor/Document.cs
@@ -1722,7 +1722,6 @@ namespace com.github.hkrn.gltf
                     Source = sourceID,
                     Name = sampledTextureUnit.Name,
                 };
-                WriteStream(sampledTextureUnit.Data);
                 var textureID = new ObjectID((uint)root.Textures!.Count);
                 root.Samplers!.Add(sampler);
                 root.Textures!.Add(texture);


### PR DESCRIPTION
## Summary

The PR fixes a bug where `WriteStream` was called twice.

## Details

During the process of adding unit tests, a bug was discovered where` WriteStream` was being called twice within `Exporter.CreateSampledTexture`. The issue occurred because `Exporter.CreateTextureSource`, which is called internally, had already written the necessary data. As a result, the subsequent `WriteStream` call wrote unused data, unnecessarily increasing the VRM file size.

This problem arose because `GltfDocumentTest.ExporterCreateSampledTexture` was not verifying the actual written data size. A new test has been added to ensure that the data size matches expectations. While the reduction depends on texture size, this change is expected to reduce VRM file size by up to nearly half.

Additionally, since the related PR #14 has been merged, the ignore directive for the `GltfDocumentTest.ExporterCreateSparseAccessorVector3_Indices` test has been removed.