### PR TITLE
[exporter] fix issue where multiple PB colliders were not considered

### DIFF
--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -2596,9 +2596,16 @@ namespace com.github.hkrn
                 {
                     if (!transform.gameObject.activeInHierarchy ||
                         component.excludedSpringBoneColliderTransforms.Contains(transform) ||
-                        !transform.TryGetComponent<VRCPhysBoneCollider>(out var collider))
+                        !transform.TryGetComponent<VRCPhysBoneCollider>(out _))
+                    {
                         continue;
-                    ConvertBoneCollider(collider, ref pbColliders, ref colliders);
+                    }
+
+                    var innerColliders = transform.GetComponents<VRCPhysBoneCollider>();
+                    foreach (var innerCollider in innerColliders!)
+                    {
+                        ConvertBoneCollider(innerCollider, ref pbColliders, ref colliders);
+                    }
                 }
 
                 foreach (var (transform, _) in _transformNodeIDs)


### PR DESCRIPTION
## Summary

This PR fixes an issue where multiple PB colliders were not considered

## Details

Previously, cases where a single game object contained multiple PB colliders were not accounted for. This is necessary, for example, when combining multiple sphere colliders to approximate a capsule collider. This update adds support for such cases.

While, in principle, multiple PBs and constraints could also be supported, this commit does not address that.