### PR TITLE
[exporter] Change NDMF compatible version to 1.6 or higher but less than 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "repo": "https://hkrn.github.io/vpm.json",
   "vpmDependencies": {
     "com.vrchat.avatars": ">=3.7.0",
-    "nadena.dev.ndmf": "^1.6.0"
+    "nadena.dev.ndmf": ">=1.6.0 < 2.0.0"
   }
 }


### PR DESCRIPTION
## Summary

This PR changes NDMF compatible version to 1.6 or higher but less than 2.0

## Details

We are making the above change because the current version specification may prevent compatibility with NDMF 1.7 or higher, which is expected to be released soon.