### PR TITLE
[exporter] Add vertex index corruption detection processing

### DIFF
--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -233,4 +233,4 @@ msgid "component.runtime.error.validation.license-url"
 msgstr "Building VRM file will be skipped due to required license URL property is empty or invalid"
 
 msgid "component.runtime.error.validation.smr"
-msgstr "Building VRM file will be skipped due to corrupted SkinnedMeshRenderer found"
+msgstr "Building VRM file will be skipped due to corrupted SkinnedMeshRenderer found. You will need to convert it to MeshRenderer or recreate the project."

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ lilToon 以外のシェーダが使われている場合は MToon の変換は�
 * `Authors` 設定が入っていない
 * `License URL` 設定が URL 形式として不正
 
-ただしごく稀に Skinned Mesh Renderer の実行時破損検出処理で NDMF のコンソールにエラーとして表示されることがあります。これは本来起こり得るエラーではないため VRM 書き出しを諦めるかプロジェクトの作り直しが必要になります。
+ただし [Skinned Mesh Renderer](https://docs.unity3d.com/ja/2022.3/Manual/class-SkinnedMeshRenderer.html) の実行時破損検出処理で NDMF のコンソールにエラーとして表示されることがあります。その場合は該当する Skinned Mesh Renderer を [Mesh Renderer](https://docs.unity3d.com/ja/2022.3/Manual/class-MeshRenderer.html) に変更するか、プロジェクトの作り直しが必要になります。
 
 ### 出力した VRM 1.0 アバターを 0.x にダウングレードできますか？
 


### PR DESCRIPTION
## Summary

This PR adds vertex index corruption detection processing.

## Details

As a countermeasure for GH-38, we will add a process to check that the index references are correct in the Skinned Mesh Renderer corruption detection. We will also make improvements to enable corruption detection for multiple Skinned Mesh Renderers.