### PR TITLE
[exporter] Fixes a bug where source joints were included when `Multi-Child Type` was set to `Ignore`

### DIFF
--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -4097,8 +4097,29 @@ namespace com.github.hkrn
                 var index = 1;
                 foreach (var transforms in newChains)
                 {
-                    var name = hasChainBranch ? $"{pb.name}.{index}" : pb.name;
-                    ConvertSpringBoneInner(pb, name, transforms, pbColliders, colliderGroups, ref springs);
+                    switch (hasChainBranch)
+                    {
+                        case true when pb.multiChildType == VRCPhysBoneBase.MultiChildType.Ignore && index == 1:
+                        {
+                            var name = $"{pb.name}.{index}";
+                            ConvertSpringBoneInner(pb, name, transforms.Skip(1).ToImmutableList(), pbColliders,
+                                colliderGroups, ref springs);
+                            break;
+                        }
+                        case true:
+                        {
+                            var name = $"{pb.name}.{index}";
+                            ConvertSpringBoneInner(pb, name, transforms, pbColliders, colliderGroups, ref springs);
+                            break;
+                        }
+                        default:
+                        {
+                            var name = pb.name;
+                            ConvertSpringBoneInner(pb, name, transforms, pbColliders, colliderGroups, ref springs);
+                            break;
+                        }
+                    }
+
                     index++;
                 }
             }

--- a/README.md
+++ b/README.md
@@ -252,14 +252,20 @@ VRM Spring Bone と VRC PhysBone は計算方法が異なるため結果は同�
 
 * `Ignore Transforms`
 * `Endpoint Position`
-* `Multi Child Type`
-  * `Ignore` と同じ
 * `Grab & Pose`
 
 > [!TIP]
-> 枝分かれが存在する場合はスプリングボーン名に `.${番号}` が末尾に付与されます。番号は 1 からはじまり、たとえばスプリングボーン名が `SB` で 2 つ存在する場合は `SB.1` と `SB.2` になります。
+> 枝分かれが生成される場合スプリングボーン名に `.${番号}` が末尾に付与されます。番号は 1 からはじまり、たとえばスプリングボーン名が `SB` で 2 つ存在する場合は `SB.1` と `SB.2` になります。
 
-VRC PhysBone の子孫に枝分かれが存在する場合はそれぞれが独立した VRM Spring Bone として作られます。[^9] ただし VRM の仕様では枝分かれした Spring Bone の動作は [未定義で実装依存](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_springBone-1.0/README.ja.md#%E5%88%86%E5%B2%90%E3%81%99%E3%82%8B-springchain-%E6%9C%AA%E5%AE%9A%E7%BE%A9) となるため、動作の一貫性を重視する場合は枝分かれをしないように VRC PhysBone を再設定する必要があります。
+VRC PhysBone の子孫に枝分かれが存在する場合は `Multi-Child Type` に基づき以下の対応が行われます。
+
+* `Ignore`
+  * 分岐元が含まれないそれぞれ独立した VRM Spring Bone のジョイント集合が作られます [^9]
+* `First`
+  * 分岐元が含まれる VRM Spring Bone のジョイント集合として作られます
+  * VRM の仕様では分岐が含まれる Spring Bone の動作は [未定義で実装依存](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_springBone-1.0/README.ja.md#%E5%88%86%E5%B2%90%E3%81%99%E3%82%8B-springchain-%E6%9C%AA%E5%AE%9A%E7%BE%A9) のため動作の一貫性が取れない可能性があります
+* `Average`
+  * 同等の実装ができないため First と同じ扱いで処理します
 
 VRC PhysBone のコライダーは以下の三種類に対応しています。
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where source joints were included when `Multi-Child Type` was set to `Ignore`.

## Details

(none)