### PR TITLE
[exporter] Added output of information in NDMF dialog when ShadingToony is `NaN`

### DIFF
--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -234,3 +234,6 @@ msgstr "Building VRM file will be skipped due to required license URL property i
 
 msgid "component.runtime.error.validation.smr"
 msgstr "Building VRM file will be skipped due to corrupted SkinnedMeshRenderer found. You will need to convert it to MeshRenderer or recreate the project."
+
+msgid "component.runtime.error.mtoon.nan"
+msgstr "The Shade Toony included in this material will be exported as NaN. Therefore, it may not load correctly in applications that use MToon. To prevent this, please adjust either Border or Blur in Color > Shadow."


### PR DESCRIPTION
## Summary

This PR adds output of information in NDMF dialog when ShadingToony is `NaN`

## Details

Implemented as an emergency measure for GH-47. While this doesn't prevent VRM output itself as it's a valid glTF, it provides information that the file may not be loadable as a VRM.

The permanent solution depends on the response to https://github.com/lilxyzw/lilToon/issues/263