### PR TITLE
[exporter] Remove workaround for `ShadeToony` becoming `NaN`

### DIFF
--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -235,9 +235,6 @@ msgstr "Building VRM file will be skipped due to required license URL property i
 msgid "component.runtime.error.validation.smr"
 msgstr "Building VRM file will be skipped due to corrupted SkinnedMeshRenderer found. You will need to convert it to MeshRenderer or recreate the project."
 
-msgid "component.runtime.error.mtoon.nan"
-msgstr "The Shade Toony included in this material will be exported as NaN. Therefore, it may not load correctly in applications that use MToon. To prevent this, please adjust either Border or Blur in Color > Shadow."
-
 msgid "component.runtime.error.mesh.oob-materials"
 msgstr "Since there are more submeshes than materials, submeshes with indices greater than the number of materials will have the default material applied. This may result in unintended conversion results."
 


### PR DESCRIPTION
## Summary

This PR remove workaround for `ShadeToony` becoming `NaN`.

## Details

Applied the same conversion formula since a fix commit was made on the lilToon side
https://github.com/lilxyzw/lilToon/commit/0648caedc9e70a9da946a56d31efe693c7b632bb

Since the above prevents `NaN` from occurring, the workaround has been removed.