### PR TITLE
[asmdef] removes upper version constraint

### DIFF
--- a/Editor/NDMFVRMExporter.asmdef
+++ b/Editor/NDMFVRMExporter.asmdef
@@ -27,22 +27,22 @@
     "versionDefines": [
         {
             "name": "com.anatawa12.avatar-optimizer",
-            "expression": "[1.8,2.0)",
+            "expression": "1.8",
             "define": "NVE_HAS_AVATAR_OPTIMIZER"
         },
         {
             "name": "com.vrchat.avatars",
-            "expression": "[3.7,4.0)",
+            "expression": "3.7",
             "define": "NVE_HAS_VRCHAT_AVATAR_SDK"
         },
         {
             "name": "jp.lilxyzw.liltoon",
-            "expression": "[1.8,2.0)",
+            "expression": "1.8",
             "define": "NVE_HAS_LILTOON"
         },
         {
             "name": "nadena.dev.ndmf",
-            "expression": "[1.6,2.0)",
+            "expression": "1.6",
             "define": "NVE_HAS_NDMF"
         }
     ],


### PR DESCRIPTION
## Summary

This PR removes the upper limit from version constraints in asmdef

## Details

I plan to change this if completely incompatible changes occur, but this addresses the issue where the current version constraints cause everything to become Standard shader and prevent lilToon conversion due to the recent release of lilToon 2.x. While lilToon 2.x has removed unused features, this has no impact since NDMF VRM Exporter does not support conversion for those.