### PR TITLE
[exporter] Skip when mesh primitives do not exist

### DIFF
--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -77,7 +77,7 @@ msgid "component.metadata.information.vrchat.cancel"
 msgstr "Cancel"
 
 msgid "component.metadata.information.vrchat.error.authorization"
-msgstr "Failed to authorize VRChat. Try sign-in from VRChat SDK control panel."
+msgstr "Failed to authorize VRChat. Try sign-in from VRChat SDK control panel"
 
 msgid "component.metadata.licenses.license-url"
 msgstr "License URL"
@@ -233,10 +233,13 @@ msgid "component.runtime.error.validation.license-url"
 msgstr "Building VRM file will be skipped due to required license URL property is empty or invalid"
 
 msgid "component.runtime.error.validation.smr"
-msgstr "Building VRM file will be skipped due to corrupted SkinnedMeshRenderer found. You will need to convert it to MeshRenderer or recreate the project."
+msgstr "Building VRM file will be skipped due to corrupted SkinnedMeshRenderer found. You will need to convert it to MeshRenderer or recreate the project"
 
 msgid "component.runtime.error.mesh.oob-materials"
-msgstr "Since there are more submeshes than materials, submeshes with indices greater than the number of materials will have the default material applied. This may result in unintended conversion results."
+msgstr "Since there are more submeshes than materials, submeshes with indices greater than the number of materials will have the default material applied. This may result in unintended conversion results"
 
 msgid "component.runtime.error.mesh.no-material"
-msgstr "The submesh output was skipped because there is no material reference for the submesh. Please verify that the material reference is set correctly."
+msgstr "The submesh output was skipped because there is no material reference for the submesh. Please verify that the material reference is set correctly"
+
+msgid "component.runtime.error.mesh.no-primitive"
+msgstr "Mesh output will be skipped because the mesh entity does not exist"

--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -2607,7 +2607,15 @@ namespace com.github.hkrn
                 });
             }
 
-            node.Mesh = _exporter.CreateMesh(_root, meshUnit);
+            if (meshUnit.Primitives.Count > 0)
+            {
+                node.Mesh = _exporter.CreateMesh(_root, meshUnit);
+            }
+            else
+            {
+                ErrorReport.ReportError(Translator.Instance, ErrorSeverity.Information,
+                    "component.runtime.error.mesh.no-primitive", parentTransform.gameObject);
+            }
         }
 
         private static gltf.exporter.SampledTextureUnit ExportTextureUnit(Texture texture, string name,


### PR DESCRIPTION
## Summary

This PR skips mesh node when mesh primitives do not exist.

## Details

According to the glTF specification, mesh primitives are required elements when outputting meshes and cannot be an empty set. Therefore, when mesh primitives are empty, mesh output will be skipped. This prevents loading failures caused by mesh primitives being empty elements.

c.f. https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#_mesh_primitives