### PR TITLE
[exporter] Fixed a bug where hidden bones are referenced

### DIFF
--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -2301,7 +2301,8 @@ namespace com.github.hkrn
 
                 foreach (var transform in bones)
                 {
-                    if (!transform || _transformMap.TryGetValue(transform, out var offset))
+                    if (!transform || !transform.gameObject.activeInHierarchy ||
+                        _transformMap.TryGetValue(transform, out var offset))
                     {
                         continue;
                     }


### PR DESCRIPTION
## Summary

This PR fixes a bug where hidden bones are referenced.

## Details

Likely due to the effects of GH-66, found a bug where bones from hidden SMRs are referenced when they should not be, causing `KeyNotFoundException` in the following location. This has been fixed to not add them when they are hidden.

```csharp
var joints = resolver.UniqueTransforms.Select(bone => _transformNodeIDs[bone]).ToList();
```