### PR TITLE
[exporter] Fixed a bug where NaN is output

### DIFF
--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -4189,7 +4189,8 @@ namespace com.github.hkrn
                         }
 
                         var (upperDepth, lowerDepth) = FindTransformDepth(transform, rootTransform);
-                        var depthRatio = upperDepth / (float)(upperDepth + lowerDepth);
+                        var totalDepth = upperDepth + lowerDepth;
+                        var depthRatio = totalDepth != 0 ? upperDepth / (float)totalDepth : 0;
                         var evaluate = new Func<float, AnimationCurve, float>((value, curve) =>
                             curve.length > 0
                                 ? curve.Evaluate(depthRatio) * value


### PR DESCRIPTION
## Summary

This PR fixes a bug where NaN is output

## Details

There was a bug where `depthRatio` would receive NaN due to division by zero, and when serialized as JSON, NaN values are treated as strings, making the file unreadable as VRM (since the bug is limited to VRM spring bones, there's no issue when treated as glTF). This has been fixed to check if the value is zero and return 0 if it is zero.