### PR TITLE
[exporter] Fixed to exclude root influence from `offsetFromHeadBone`

### DIFF
--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -3698,7 +3698,8 @@ namespace com.github.hkrn
                 var descriptor = _gameObject.GetComponent<VRCAvatarDescriptor>();
                 var animator = _gameObject.GetComponent<Animator>();
                 var head = animator.GetBoneTransform(HumanBodyBones.Head);
-                var offsetFromHeadBone = descriptor.ViewPosition - head.position;
+                var headPosition = head.position - _gameObject.transform.position;
+                var offsetFromHeadBone = descriptor.ViewPosition - headPosition;
                 core.LookAt = new vrm.core.LookAt
                 {
                     Type = vrm.core.LookAtType.Bone,


### PR DESCRIPTION
## Summary

This PR fixes an issue of GH-73.

## Details

When setting `offsetFromHeadBone`, the position of the root object was not being considered, causing incorrect positions to be set in `offsetFromHeadBone` when it was configured. This has been fixed to subtract the root object's position. This is expected to fix GH-73.