### PR TITLE
[exporter] Fixed to apply original values when `AnimationCurve` is null

### DIFF
--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -4193,7 +4193,7 @@ namespace com.github.hkrn
                         var totalDepth = upperDepth + lowerDepth;
                         var depthRatio = totalDepth != 0 ? upperDepth / (float)totalDepth : 0;
                         var evaluate = new Func<float, AnimationCurve, float>((value, curve) =>
-                            curve.length > 0
+                            curve is { length: > 0 }
                                 ? curve.Evaluate(depthRatio) * value
                                 : value);
                         var gravity = evaluate(pb.gravity, pb.gravityCurve);


### PR DESCRIPTION
## Summary

This PR fixes to apply original values when `AnimationCurve` is null.

## Details

Since a pattern where `AnimationCurve` is null was reported in GH-75, handles the processing equivalent to `curve != null && curve.length > 0` with an is-pattern. This ensures that even if the same phenomenon occurs, it will not result in an error.