### PR TITLE
[exporter] implements `KHR_materials_variants`

### DIFF
--- a/Editor/Document.cs
+++ b/Editor/Document.cs
@@ -1496,6 +1496,78 @@ namespace com.github.hkrn.gltf
                 };
             }
         }
+
+        public sealed class KhrMaterialsVariants : ICloneable
+        {
+            public static readonly string Name = "KHR_materials_variants";
+            public IList<KhrMaterialsVariantsItem> Variants { get; init; } = new List<KhrMaterialsVariantsItem>();
+            public IExtensions? Extensions { get; set; }
+            public JToken? Extras { get; set; }
+
+            public object Clone()
+            {
+                return new KhrMaterialsVariants
+                {
+                    Variants = Variants,
+                    Extensions = ExtensionsUtils.DeepClone(Extensions),
+                    Extras = Extras?.DeepClone(),
+                };
+            }
+        }
+
+        public sealed class KhrMaterialsVariantsItem : ICloneable
+        {
+            public UnicodeString? Name { get; set; }
+            public IExtensions? Extensions { get; set; }
+            public JToken? Extras { get; set; }
+
+            public object Clone()
+            {
+                return new KhrMaterialsVariantsItem
+                {
+                    Name = Name,
+                    Extensions = ExtensionsUtils.DeepClone(Extensions),
+                    Extras = Extras?.DeepClone(),
+                };
+            }
+        }
+
+        public sealed class KhrMaterialsVariantsPrimitive : ICloneable
+        {
+            public IList<KhrMaterialsVariantsPrimitiveMapping> Mappings { get; init; } =
+                new List<KhrMaterialsVariantsPrimitiveMapping>();
+            public IExtensions? Extensions { get; set; }
+            public JToken? Extras { get; set; }
+
+            public object Clone()
+            {
+                return new KhrMaterialsVariantsPrimitive
+                {
+                    Mappings = Mappings,
+                    Extensions = ExtensionsUtils.DeepClone(Extensions),
+                    Extras = Extras?.DeepClone(),
+                };
+            }
+        }
+
+        public sealed class KhrMaterialsVariantsPrimitiveMapping : ICloneable
+        {
+            public ObjectID Material { get; set; }
+            public IList<ObjectID> Variants { get; init; } = new List<ObjectID>();
+            public IExtensions? Extensions { get; set; }
+            public JToken? Extras { get; set; }
+
+            public object Clone()
+            {
+                return new KhrMaterialsVariantsPrimitiveMapping
+                {
+                    Material = Material,
+                    Variants = Variants,
+                    Extensions = ExtensionsUtils.DeepClone(Extensions),
+                    Extras = Extras?.DeepClone(),
+                };
+            }
+        }
     }
 
     namespace exporter
@@ -2664,6 +2736,16 @@ namespace com.github.hkrn.gltf
         }
 
         public static JToken SaveAsNode(extensions.KhrTextureBasisu value)
+        {
+            return JToken.FromObject(value, JsonSerializer.Create(SerializerOptions));
+        }
+
+        public static JToken SaveAsNode(extensions.KhrMaterialsVariants value)
+        {
+            return JToken.FromObject(value, JsonSerializer.Create(SerializerOptions));
+        }
+
+        public static JToken SaveAsNode(extensions.KhrMaterialsVariantsPrimitive value)
         {
             return JToken.FromObject(value, JsonSerializer.Create(SerializerOptions));
         }

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -37,6 +37,12 @@ msgstr "Spring Bone Options"
 msgid "component.category.constraint"
 msgstr "Constraint Options"
 
+msgid "component.category.extension"
+msgstr "glTF Extension Options"
+
+msgid "component.extension.enable-khr-materials-variants"
+msgstr "Enable KHR_materials_variants"
+
 msgid "component.category.debug"
 msgstr "Debug Options"
 

--- a/Editor/NDMFVRMExporter.asmdef
+++ b/Editor/NDMFVRMExporter.asmdef
@@ -4,7 +4,9 @@
     "references": [
         "GUID:62ced99b048af7f4d8dfe4bed8373d76",
         "GUID:fe747755f7b44e048820525b07f9b956",
+        "GUID:fc900867c0f47cd49b6e2ae4ef907300",
         "GUID:ac4815c6727e4e34b9e13bb042cbc029",
+        "GUID:1361f424038d2644fa9897816cda865f",
         "GUID:e7f0f8dffe955d640bbc76d1d4f4986e",
         "GUID:6e9c6119ac4eb334284fb7b4bc6d1f05"
     ],
@@ -36,6 +38,11 @@
             "define": "NVE_HAS_VRCHAT_AVATAR_SDK"
         },
         {
+            "name": "jp.lilxyzw.lilycalinventory",
+            "expression": "1.0",
+            "define": "NVE_HAS_LILYCAL_INVENTORY"
+        },
+        {
             "name": "jp.lilxyzw.liltoon",
             "expression": "1.8",
             "define": "NVE_HAS_LILTOON"
@@ -44,6 +51,11 @@
             "name": "nadena.dev.ndmf",
             "expression": "1.6",
             "define": "NVE_HAS_NDMF"
+        },
+        {
+            "name": "nadena.dev.modular-avatar",
+            "expression": "1.13",
+            "define": "NVE_HAS_MODULAR_AVATAR"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
## Summary

This PR implements exporting `KHR_materials_variants` extension.

## Details

As described in the README, this adds functionality to convert to `KHR_materials_variants` when lilycalInventory or Modular Avatar's corresponding components are attached. Additionally, since a new option is being added for whether to convert to `KHR_materials_variants`, the minor version will be incremented to `1.1.0`.