### PR TITLE
[exporter] adds support of NDMF platform API

### DIFF
--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -19,6 +19,12 @@ msgstr "The component must be set on root of Avatar"
 msgid "component.validation.not-enabled"
 msgstr "VRM file will not be exported due to the component is not enabled"
 
+msgid "component.platform-build.suggestion"
+msgstr "VRM can be exported by clicking below \"Open NDMF Console to export VRM file\" button"
+
+msgid "component.platform-build.open"
+msgstr "Open NDMF Console to export VRM file"
+
 msgid "component.validation.avatar-thumbnail"
 msgstr "Avatar thumbnail image must be square"
 
@@ -228,9 +234,6 @@ msgstr "KTX Tool Path"
 
 msgid "component.runtime.error.validation.not-attached"
 msgstr "Building VRM file will be skipped due to the component is not attached"
-
-msgid "component.runtime.error.validation.not-enabled"
-msgstr "Building VRM file will be skipped due to the component is not enabled"
 
 msgid "component.runtime.error.validation.author"
 msgstr "Building VRM file will be skipped due to required authors property is empty"

--- a/Editor/NDMFVRMExporter.asmdef
+++ b/Editor/NDMFVRMExporter.asmdef
@@ -4,6 +4,7 @@
     "references": [
         "GUID:62ced99b048af7f4d8dfe4bed8373d76",
         "GUID:fe747755f7b44e048820525b07f9b956",
+        "GUID:901e56b065a857d4483a77f8cae73588",
         "GUID:fc900867c0f47cd49b6e2ae4ef907300",
         "GUID:ac4815c6727e4e34b9e13bb042cbc029",
         "GUID:1361f424038d2644fa9897816cda865f",
@@ -11,7 +12,28 @@
         "GUID:6e9c6119ac4eb334284fb7b4bc6d1f05"
     ],
     "includePlatforms": [],
-    "excludePlatforms": [],
+    "excludePlatforms": [
+        "Android",
+        "EmbeddedLinux",
+        "GameCoreScarlett",
+        "GameCoreXboxOne",
+        "iOS",
+        "LinuxStandalone64",
+        "CloudRendering",
+        "macOSStandalone",
+        "PS4",
+        "PS5",
+        "QNX",
+        "Stadia",
+        "Switch",
+        "tvOS",
+        "WSA",
+        "VisionOS",
+        "WebGL",
+        "WindowsStandalone32",
+        "WindowsStandalone64",
+        "XboxOne"
+    ],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
@@ -51,6 +73,11 @@
             "name": "nadena.dev.ndmf",
             "expression": "1.6",
             "define": "NVE_HAS_NDMF"
+        },
+        {
+            "name": "nadena.dev.ndmf",
+            "expression": "1.8",
+            "define": "NVE_HAS_NDMF_PLATFORM_SUPPORT"
         },
         {
             "name": "nadena.dev.modular-avatar",

--- a/Editor/NdmfVrmExporterBuildState.cs
+++ b/Editor/NdmfVrmExporterBuildState.cs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2024-present hkrn
+// SPDX-License-Identifier: MPL
+
+#if NVE_HAS_NDMF_PLATFORM_SUPPORT
+using nadena.dev.ndmf.platform;
+
+// ReSharper disable once CheckNamespace
+namespace com.github.hkrn
+{
+    internal class NdmfVrmExporterBuildState
+    {
+        // ReSharper disable once NotAccessedField.Global
+        public CommonAvatarInfo CommonAvatarInfo;
+    }
+}
+#endif // NVE_HAS_NDMF_PLATFORM_SUPPORT

--- a/Editor/NdmfVrmExporterBuildState.cs.meta
+++ b/Editor/NdmfVrmExporterBuildState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67a406079b794b48a9db78d3bd06742b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/NdmfVrmExporterPlatform.cs
+++ b/Editor/NdmfVrmExporterPlatform.cs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2024-present hkrn
+// SPDX-License-Identifier: MPL
+
+#if NVE_HAS_NDMF_PLATFORM_SUPPORT
+using nadena.dev.ndmf;
+using nadena.dev.ndmf.platform;
+
+// ReSharper disable once CheckNamespace
+namespace com.github.hkrn
+{
+    [NDMFPlatformProvider]
+    internal class NdmfVrmExporterPlatform : INDMFPlatformProvider
+    {
+        public string QualifiedName => NdmfVrmExporterPlugin.Instance.QualifiedName;
+        public string DisplayName => "VRM 1.0 (NDMF VRM Exporter)";
+
+        public BuildUIElement CreateBuildUI() => new ui.NdmfVrmExporterBuildUI();
+
+        internal static readonly NdmfVrmExporterPlatform Instance = new();
+        internal string LastBuildDirectory { get; set; } = string.Empty;
+        internal string LastBuildFileNameWithoutExtension { get; set; } = "Untitled";
+
+        public void InitBuildFromCommonAvatarInfo(BuildContext context, CommonAvatarInfo info)
+        {
+            context.GetState<NdmfVrmExporterBuildState>().CommonAvatarInfo = info;
+        }
+    }
+}
+#endif // NVE_HAS_NDMF_PLATFORM_SUPPORT

--- a/Editor/NdmfVrmExporterPlatform.cs.meta
+++ b/Editor/NdmfVrmExporterPlatform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55f4fda1eb5f4a66995054a1ac8d7a19
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/UI.meta
+++ b/Editor/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 02ac4f95ee094cba8e97f252a9d800dc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/UI/NdmfVrmExporterBuildUI.cs
+++ b/Editor/UI/NdmfVrmExporterBuildUI.cs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2024-present hkrn
+// SPDX-License-Identifier: MPL
+
+#if NVE_HAS_NDMF_PLATFORM_SUPPORT
+using System.IO;
+using nadena.dev.ndmf;
+using nadena.dev.ndmf.platform;
+using UnityEngine.UIElements;
+using UnityEditor;
+using UnityEngine;
+using VRC.SDK3.Editor;
+
+// ReSharper disable once CheckNamespace
+namespace com.github.hkrn.ui
+{
+    internal class NdmfVrmExporterBuildUI : BuildUIElement
+    {
+        public NdmfVrmExporterBuildUI()
+        {
+            var visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(
+                $"Packages/{NdmfVrmExporter.PackageJson.Name}/Editor/UI/Resources/NDMFVRMExporter.uxml");
+            var rootContainer = visualTree.CloneTree();
+            Add(rootContainer);
+            _exportButton = rootContainer.Q<Button>("export");
+            _messageLabel = rootContainer.Q<Label>("message");
+            _exportButton.clicked += () =>
+            {
+                _exportButton.SetEnabled(false);
+                _messageLabel.SetVisible(false);
+                var platformInstance = NdmfVrmExporterPlatform.Instance;
+                var path = EditorUtility.SaveFilePanel("Export VRM File", platformInstance.LastBuildDirectory,
+                    platformInstance.LastBuildFileNameWithoutExtension, "vrm");
+                if (string.IsNullOrEmpty(path))
+                {
+                    Debug.Log("Exporting VRM has been cancelled");
+                    _exportButton.SetEnabled(true);
+                    return;
+                }
+
+                Build(platformInstance, path);
+            };
+        }
+
+        private void Build(NdmfVrmExporterPlatform platform, string path)
+        {
+            GameObject avatarRoot = null;
+            try
+            {
+                avatarRoot = Object.Instantiate(AvatarRoot);
+                avatarRoot.name = avatarRoot.name[..^"(clone)".Length];
+                using var scope = new AmbientPlatform.Scope(platform);
+                using var scope2 = new OverrideTemporaryDirectoryScope(null);
+                var buildContext = AvatarProcessor.ProcessAvatar(avatarRoot, platform);
+                if (!avatarRoot.TryGetComponent<NdmfVrmExporterComponent>(out var component))
+                {
+                    ErrorReport.ReportError(Translator.Instance, ErrorSeverity.NonFatal,
+                        "component.runtime.error.validation.not-attached");
+                    return;
+                }
+
+                var outputDirectory = Path.GetDirectoryName(path) ?? string.Empty;
+                var outputFileNameWithoutExtension = Path.GetFileNameWithoutExtension(path) ?? string.Empty;
+                var baseOutputPath = Path.Join(outputDirectory, outputFileNameWithoutExtension);
+                var workingDirectoryPath = AssetPathUtils.GetTempPath(avatarRoot);
+                try
+                {
+                    NdmfVrmExporterPlugin.ExportVrmFile(component, buildContext, baseOutputPath,
+                        workingDirectoryPath);
+                    platform.LastBuildDirectory = outputDirectory;
+                    platform.LastBuildFileNameWithoutExtension = outputFileNameWithoutExtension;
+                    EditorUtility.DisplayDialog(NdmfVrmExporterPlugin.Instance.DisplayName,
+                        "Exporting VRM has been completed!", "OK");
+                }
+                catch (NdmfVrmExporterPlugin.ValidationException e)
+                {
+                    if (e.Extras != null)
+                    {
+                        ErrorReport.ReportError(Translator.Instance, ErrorSeverity.NonFatal,
+                            e.Key, e.Extras);
+                    }
+                    else
+                    {
+                        _messageLabel.SetVisible(true);
+                        _messageLabel.text = e.Message;
+                    }
+                }
+            }
+            finally
+            {
+                if (avatarRoot)
+                {
+                    Object.DestroyImmediate(avatarRoot);
+                }
+                _exportButton.SetEnabled(true);
+            }
+        }
+
+        private readonly Button _exportButton;
+        private readonly Label _messageLabel;
+    }
+}
+#endif // NVE_HAS_NDMF_PLATFORM_SUPPORT

--- a/Editor/UI/NdmfVrmExporterBuildUI.cs.meta
+++ b/Editor/UI/NdmfVrmExporterBuildUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 854d909e4ad5474587f7b66e5f8988b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/UI/Resources.meta
+++ b/Editor/UI/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fdd818426a874d2891e1129d1a69af5b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/UI/Resources/NDMFVRMExporter.uxml
+++ b/Editor/UI/Resources/NDMFVRMExporter.uxml
@@ -1,0 +1,6 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <ui:VisualElement name="VisualElement" style="flex-grow: 1;">
+        <ui:Button text="Export" parse-escape-sequences="true" display-tooltip-when-elided="true" name="export" />
+        <ui:Label tabindex="-1" parse-escape-sequences="true" display-tooltip-when-elided="true" name="message" style="display: none;" />
+    </ui:VisualElement>
+</ui:UXML>

--- a/Editor/UI/Resources/NDMFVRMExporter.uxml.meta
+++ b/Editor/UI/Resources/NDMFVRMExporter.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b7558393dc85d4e11817bab0b74dbe61
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ NDMF VRM Exporter には以下の特徴を持っています。
 
 レポジトリ導入後は `NDMF VRM Exporter` を検索してインストールすることで利用可能になります。
 
-## 使い方
+## 使い方その１
+
+Unity を再生あるいは VRChat にアップロードする際にビルドと共に書き出す方法です。
 
 1. インスペクタ画面から `VRC Avatar Descriptor` があるところで `Add Component` から `VRM Export Description` コンポーネントを検索し設定
 2. `VRM Export Description` コンポーネント内にある `Retrieve Metadata via VRChat API` で自動設定
@@ -35,12 +37,34 @@ NDMF VRM Exporter は出力した VRM ファイルを閲覧する機能を持っ
 
 アップロードして確認する場合は [VRoid Hub](https://hub.vroid.com) の利用を推奨します。
 
+### 使い方その２
+
+> [!IMPORTANT]
+> NDMF 1.8 以上 (Modular Avatar では 1.13 以上が対応) が導入されている必要があります
+
+NDMF に組み込まれているアバタープラットフォーム機能を利用する方法です。「使い方その１」と異なり、コンポーネントを無効にしても機能し必要なタイミングで任意の場所に対して VRM ファイルの出力が可能となります。
+
+1. インスペクタ画面から `VRC Avatar Descriptor` があるところで `Add Component` から `VRM Export Description` コンポーネントを検索し設定
+2. `VRM Export Description` コンポーネント内にある `Retrieve Metadata via VRChat API` で自動設定
+  * アバターが未アップロードなどの理由で手動設定する場合は `Authors` の左横の ▶️ をクリックして 🔽 にしたのち、➕ ボタンで作者名を設定
+3. `VRM Export Description` 左横のチェックボタンを外して無効化
+  * 有効化したままの場合はメニューの `Tools > NDM Framework > Show NDMF Console` でウィンドウを開く必要があります
+4. 無効にした際に現れる `Open NDMF Console to export VRM file` ボタンを押す
+5. `Avatar platform` から `VRM 1.0 (NDMF VRM Exporter)` を選択
+6. `Avatar platform` の項目のすぐ下に出てくる `Export` ボタンを押す
+7. ファイルダイアログが開くので出力先を指定
+
 ## コンポーネントの説明
 
-NDMF VRM Exporter が提供するコンポーネントは `VRM Export Description` のひとつのみです。コンポーネントを有効にした状態（コンポーネント名の横にチェックボックス ✅ がついてる状態）で再生すると VRM ファイルが生成される仕組みとなっています。
+NDMF VRM Exporter が提供するコンポーネントは `VRM Export Description` のひとつのみです。
+
+* コンポーネントを有効にした状態（コンポーネント名の横にチェックボックス ✅ がついてる状態）で再生
+* コンポーネントの有効無効にかかわらず NDMF Console からプラットフォーム選択で `NDMF VRM Exporter` を選び Export した場合
+
+上記のいずれかによって VRM ファイルが生成される仕組みとなっています。
 
 > [!TIP]
-> 処理の性質上 VRM ファイルの生成は最低でも数秒、場合によっては数分と時間がかかるため、[AV3 Emulator](https://github.com/lyuma/Av3Emulator) などを使ってアバターをデバッグする際はコンポーネントを無効にすることを推奨します
+> 処理の性質上 VRM ファイルの生成は最低でも数秒、場合によっては数分と時間がかかるため、時間がかかる場合はコンポーネントを無効化して NDMF Console 経由でファイル書き出しをしてください
 
 ### Metadata
 
@@ -200,7 +224,7 @@ MMD 互換のブレンドシェイプが存在する場合は `Set Preset Expres
 > [!TIP]
 > NDMF VRM Exporter においてリムライトを無効にしていることが条件ですが、マットキャップのマスクテクスチャを使う形でマットキャップの乗算モードを擬似的に実現可能です
 
-ただしマットキャップが「有効」かつリムライトが「無効」の場合は MToon の実装の関係でリムライトのパラメータを上書きします。詳細は「出力互換性の情報」の「材質の変換」を確認してください。
+ただしマットキャップが「有効」かつリムライトが「無効」の場合は MToon の実装の関係でリムライトのパラメータを上書きします。詳細は「出力互換性の情報」の「材質（マテリアル）の変換」を確認してください。
 
 ## Spring Bone Options
 
@@ -490,7 +514,7 @@ VRM 1.0 を出力できる点は同じですが、出力するまでの過程が
 * NDMF VRM Exporter
   * VPM 経由で NDMF VRM Exporter を導入
   * Modular Avatar で着せ替えしたアバターにコンポーネントを付与
-  * Unity から再生し、出力したファイルを取得
+  * Unity から再生または NDMF コンソール経由で書き出し、出力したファイルを取得
 
 VRoid Studio の場合は VRM の出力に XAvatar を利用する関係で VRoid Studio の導入が別途必要で、作業自体は Unity 単体で完結しません。一方で NDMF VRM Exporter は Unity 内で完結します。
 


### PR DESCRIPTION
## Summary

This PR adds support of NDMF platform API.

## Details

This adds functionality to output VRM files generated by NDMF VRM Exporter to an arbitrary path through a dialog using the Platform API introduced in NDMF 1.8. Additionally, it modifies the system to function even when the component is disabled, changes the message when disabled, and adds a new button to display the NDMF Console for convenience. Starting with this change, the implementation will be split into separate files, and `NDMFVRMExporter.cs` main body is also planned to be split in the future.

Due to a past configuration error, the asmdef is set to Any Platforms, and there is an issue where VRChat uploads become impossible when the current changes are applied. On the other hand, operational testing has confirmed that removing this and limiting it to Editor only causes a critical issue where existing component settings become corrupted. Therefore, we have confirmed that by maintaining Any Platforms while excluding everything except Editor, existing component settings remain intact and VRChat uploads become possible, so we are implementing it this way.