### PR TITLE
[exporter] Fixed a bug with unintended dependency on VRChat SDK extension method

### DIFF
--- a/Editor/UI/NdmfVrmExporterBuildUI.cs
+++ b/Editor/UI/NdmfVrmExporterBuildUI.cs
@@ -8,7 +8,6 @@ using nadena.dev.ndmf.platform;
 using UnityEngine.UIElements;
 using UnityEditor;
 using UnityEngine;
-using VRC.SDK3.Editor;
 
 // ReSharper disable once CheckNamespace
 namespace com.github.hkrn.ui
@@ -26,7 +25,7 @@ namespace com.github.hkrn.ui
             _exportButton.clicked += () =>
             {
                 _exportButton.SetEnabled(false);
-                _messageLabel.SetVisible(false);
+                _messageLabel.style.display = DisplayStyle.None;
                 var platformInstance = NdmfVrmExporterPlatform.Instance;
                 var path = EditorUtility.SaveFilePanel("Export VRM File", platformInstance.LastBuildDirectory,
                     platformInstance.LastBuildFileNameWithoutExtension, "vrm");
@@ -80,7 +79,7 @@ namespace com.github.hkrn.ui
                     }
                     else
                     {
-                        _messageLabel.SetVisible(true);
+                        _messageLabel.style.display = DisplayStyle.Flex;
                         _messageLabel.text = e.Message;
                     }
                 }


### PR DESCRIPTION
## Summary

This PR fixes a bug with unintended dependency on VRChat SDK extension method.

## Details

It was discovered that `UnityEngine.UIElements.VisualElement.SetVisible` is implemented as an extension method in the VRChat SDK, and the method is not implemented in the minimum required VRChat SDK version, causing a compilation failure. Since there should be no dependency on the VRChat SDK, this has been fixed to directly implement the original implementation.

This fixes the issue in GH-98.