### PR TITLE
[export] Implemented export disabling process

### DIFF
--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -25,6 +25,12 @@ msgstr "VRM can be exported by clicking below \"Open NDMF Console to export VRM 
 msgid "component.platform-build.open"
 msgstr "Open NDMF Console to export VRM file"
 
+msgid "component.platform-build.disabled"
+msgstr "VRM Export Description Component is not attached to the avatar and cannot be exported."
+
+msgid "component.platform-build.success"
+msgstr "Exporting VRM has been completed!"
+
 msgid "component.validation.avatar-thumbnail"
 msgstr "Avatar thumbnail image must be square"
 

--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -56,6 +56,7 @@ using nadena.dev.ndmf;
 using nadena.dev.ndmf.localization;
 using nadena.dev.ndmf.runtime;
 #if NVE_HAS_NDMF_PLATFORM_SUPPORT
+using nadena.dev.ndmf.platform;
 using nadena.dev.ndmf.ui;
 #endif // NVE_HAS_NDMF_PLATFORM_SUPPORT
 

--- a/Editor/UI/NdmfVrmExporterBuildUI.cs
+++ b/Editor/UI/NdmfVrmExporterBuildUI.cs
@@ -40,6 +40,22 @@ namespace com.github.hkrn.ui
             };
         }
 
+        public override GameObject AvatarRoot
+        {
+            get => _avatarRoot;
+            set
+            {
+                var enabled = value && value.TryGetComponent<NdmfVrmExporterComponent>(out _);
+                _exportButton.SetEnabled(enabled);
+                _messageLabel.style.display = enabled ? DisplayStyle.Flex : DisplayStyle.None;
+                if (!enabled)
+                {
+                    _messageLabel.text = Translator._("component.platform-build.disabled");
+                }
+                _avatarRoot = value;
+            }
+        }
+
         private void Build(NdmfVrmExporterPlatform platform, string path)
         {
             GameObject avatarRoot = null;
@@ -68,7 +84,7 @@ namespace com.github.hkrn.ui
                     platform.LastBuildDirectory = outputDirectory;
                     platform.LastBuildFileNameWithoutExtension = outputFileNameWithoutExtension;
                     EditorUtility.DisplayDialog(NdmfVrmExporterPlugin.Instance.DisplayName,
-                        "Exporting VRM has been completed!", "OK");
+                        Translator._("component.platform-build.success"), "OK");
                 }
                 catch (NdmfVrmExporterPlugin.ValidationException e)
                 {
@@ -96,6 +112,7 @@ namespace com.github.hkrn.ui
 
         private readonly Button _exportButton;
         private readonly Label _messageLabel;
+        private GameObject _avatarRoot;
     }
 }
 #endif // NVE_HAS_NDMF_PLATFORM_SUPPORT

--- a/Editor/UI/Resources/NDMFVRMExporter.uxml
+++ b/Editor/UI/Resources/NDMFVRMExporter.uxml
@@ -1,6 +1,7 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Packages/com.github.hkrn.ndmf-vrm-exporter/Editor/UI/Resources/NDMFVRMExporter.uss?fileID=7433441132597879392&amp;guid=8876c1f1b130819418aaaa1401de7ec8&amp;type=3#NDMFVRMExporter" />
     <ui:VisualElement name="VisualElement" style="flex-grow: 1;">
         <ui:Button text="Export" parse-escape-sequences="true" display-tooltip-when-elided="true" name="export" />
-        <ui:Label tabindex="-1" parse-escape-sequences="true" display-tooltip-when-elided="true" name="message" style="display: none;" />
+        <ui:Label tabindex="-1" parse-escape-sequences="true" display-tooltip-when-elided="true" name="message" focusable="true" style="display: none; white-space: normal; text-overflow: ellipsis;" />
     </ui:VisualElement>
 </ui:UXML>


### PR DESCRIPTION
## Summary

This PR implements export disabling process.

## Details

When VRM Export Description does not exist on the target avatar via the NDMF console, the export button will be disabled. This prevents issues where pressing the button does not perform an export due to the absence of VRM Export Description.