### PR TITLE
[exporter] Changed to use avatar name as filename

### DIFF
--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -56,7 +56,6 @@ using nadena.dev.ndmf;
 using nadena.dev.ndmf.localization;
 using nadena.dev.ndmf.runtime;
 #if NVE_HAS_NDMF_PLATFORM_SUPPORT
-using nadena.dev.ndmf.platform;
 using nadena.dev.ndmf.ui;
 #endif // NVE_HAS_NDMF_PLATFORM_SUPPORT
 

--- a/Editor/NdmfVrmExporterPlatform.cs
+++ b/Editor/NdmfVrmExporterPlatform.cs
@@ -18,7 +18,7 @@ namespace com.github.hkrn
 
         internal static readonly NdmfVrmExporterPlatform Instance = new();
         internal string LastBuildDirectory { get; set; } = string.Empty;
-        internal string LastBuildFileNameWithoutExtension { get; set; } = "Untitled";
+        internal string LastBuildFileNameWithoutExtension { get; set; } = string.Empty;
 
         public void InitBuildFromCommonAvatarInfo(BuildContext context, CommonAvatarInfo info)
         {

--- a/Editor/UI/NdmfVrmExporterBuildUI.cs
+++ b/Editor/UI/NdmfVrmExporterBuildUI.cs
@@ -27,8 +27,13 @@ namespace com.github.hkrn.ui
                 _exportButton.SetEnabled(false);
                 _messageLabel.style.display = DisplayStyle.None;
                 var platformInstance = NdmfVrmExporterPlatform.Instance;
+                var filename = platformInstance.LastBuildFileNameWithoutExtension;
+                if (string.IsNullOrEmpty(filename))
+                {
+                    filename = AvatarRoot.name;
+                }
                 var path = EditorUtility.SaveFilePanel("Export VRM File", platformInstance.LastBuildDirectory,
-                    platformInstance.LastBuildFileNameWithoutExtension, "vrm");
+                    filename, "vrm");
                 if (string.IsNullOrEmpty(path))
                 {
                     Debug.Log("Exporting VRM has been cancelled");


### PR DESCRIPTION
## Summary

This PR changes to use avatar name as filename.

## Details

When outputting via the NDMF console, the default filename is `Untitled`, but this has been changed to use the name of the avatar (more precisely, the game object) at the time of output. This reduces the effort of changing the name on the first export.