### PR TITLE
[exporter] Fixed display bug

### DIFF
--- a/Editor/UI/NdmfVrmExporterBuildUI.cs
+++ b/Editor/UI/NdmfVrmExporterBuildUI.cs
@@ -52,7 +52,7 @@ namespace com.github.hkrn.ui
             {
                 var enabled = value && value.TryGetComponent<NdmfVrmExporterComponent>(out _);
                 _exportButton.SetEnabled(enabled);
-                _messageLabel.style.display = enabled ? DisplayStyle.Flex : DisplayStyle.None;
+                _messageLabel.style.display = enabled ? DisplayStyle.None : DisplayStyle.Flex;
                 if (!enabled)
                 {
                     _messageLabel.text = Translator._("component.platform-build.disabled");


### PR DESCRIPTION
## Summary

This PR fixes display bug.

## Details

When GH-103 was implemented, there was a bug where the message was displayed when enabled, which is the opposite of what should happen (the message should be displayed when disabled). This has been fixed.