### PR TITLE
[exporter] Fix bug with unnormalized values

### DIFF
--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -1196,7 +1196,8 @@ namespace com.github.hkrn
         {
             self.ToAngleAxis(out var angle, out var axis);
             var newAxis = axis.ToVector3WithCoordinateSpace();
-            return System.Numerics.Quaternion.CreateFromAxisAngle(newAxis, -angle * Mathf.Deg2Rad);
+            var rotation = System.Numerics.Quaternion.CreateFromAxisAngle(newAxis, -angle * Mathf.Deg2Rad);
+            return System.Numerics.Quaternion.Normalize(rotation);
         }
 
         private static System.Numerics.Matrix4x4 ToMatrix4(this Matrix4x4 self)
@@ -1212,7 +1213,7 @@ namespace com.github.hkrn
         {
             var t = new Vector3(-self.m03, self.m13, self.m23);
             self.rotation.ToAngleAxis(out var angle, out var axis);
-            var r = Quaternion.AngleAxis(-angle, new Vector3(-axis.x, axis.y, axis.z));
+            var r = Quaternion.AngleAxis(-angle, new Vector3(-axis.x, axis.y, axis.z)).normalized;
             var s = new Vector3
             {
                 x = new Vector4(self.m00, self.m10, self.m20, self.m30).magnitude,


### PR DESCRIPTION
## Summary

This PR fixes bug with unnormalized values.

## Details

In `UnityExtensions.ToQuaternionWithCoordinateSpace`, quaternions were not being normalized, causing unnormalized values to be stored in glTF and violating the specification. Fixed to perform normalization. Also added normalization to `UnityExtensions.ToNormalizedMatrix` as a precaution.

Fixes #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quaternion normalization in VRM export rotation calculations to ensure accurate handling of rotational transformations during model export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->