### PR TITLE
[exporter] Change to pseudo-implement Immobile when specific conditions are met

### DIFF
--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -4350,6 +4350,12 @@ namespace com.github.hkrn
                 IImmutableList<vrm.sb.ColliderGroup> colliderGroups, ref IList<vrm.sb.Spring> springs)
             {
                 var rootTransform = pb.GetRootTransform();
+                gltf.ObjectID? centerNode = null;
+                if (pb.immobileType == VRCPhysBoneBase.ImmobileType.World && Mathf.Approximately(pb.immobile, 1.0f))
+                {
+                    var animator = _gameObject.GetComponent<Animator>();
+                    centerNode = GetRequiredHumanBoneNodeID(animator, HumanBodyBones.Hips);
+                }
                 var joints = transforms.Select(transform =>
                     {
                         var nodeID = FindTransformNodeID(transform);
@@ -4372,7 +4378,7 @@ namespace com.github.hkrn
                         var pull = evaluate(pb.pull, pb.pullCurve);
                         var immobile = evaluate(pb.immobile, pb.immobileCurve) * 0.5f;
                         float stiffnessFactor, pullFactor;
-                        if (pb.limitType != VRCPhysBoneBase.LimitType.None)
+                        if (pb.limitType != VRCPhysBoneBase.LimitType.None && !centerNode.HasValue)
                         {
                             var maxAngleX = evaluate(pb.maxAngleX, pb.maxAngleXCurve);
                             stiffnessFactor = maxAngleX > 0.0f ? 1.0f / Mathf.Clamp01(maxAngleX / 180.0f) : 0.0f;
@@ -4416,7 +4422,7 @@ namespace com.github.hkrn
                 var spring = new vrm.sb.Spring
                 {
                     Name = new gltf.UnicodeString(name),
-                    Center = null,
+                    Center = centerNode,
                     ColliderGroups = newColliderGroups.Count > 0 ? newColliderGroups.ToList() : null,
                     Joints = joints.Where(joint => joint != null).Select(joint => joint!).ToList(),
                 };

--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -4351,11 +4351,13 @@ namespace com.github.hkrn
             {
                 var rootTransform = pb.GetRootTransform();
                 gltf.ObjectID? centerNode = null;
-                if (pb.immobileType == VRCPhysBoneBase.ImmobileType.World && Mathf.Approximately(pb.immobile, 1.0f))
+                if (pb.immobileType == VRCPhysBoneBase.ImmobileType.World && Mathf.Approximately(pb.immobile, 1.0f) &&
+                    pb.immobileCurve is not { length: > 0 })
                 {
                     var animator = _gameObject.GetComponent<Animator>();
                     centerNode = GetRequiredHumanBoneNodeID(animator, HumanBodyBones.Hips);
                 }
+
                 var joints = transforms.Select(transform =>
                     {
                         var nodeID = FindTransformNodeID(transform);

--- a/docs~/compatibility.md
+++ b/docs~/compatibility.md
@@ -11,12 +11,15 @@
 > [!NOTE]
 > VRC PhysBone が登場する前に使われていた [Dynamic Bone](https://assetstore.unity.com/packages/tools/animation/dynamic-bone-16743) からの変換には対応していません
 
-VRC PhysBone については VRM Spring Bone のジョイントに変換されます。ただし Immobile および Limit については VRM Spring Bone に対応する仕様が存在しないため、「動きにくくする措置」として以下で計算されます。
+VRC PhysBone については VRM Spring Bone のジョイントに変換されます。ただし Immobile および Limit については VRM Spring Bone に直接対応する仕様が存在しないため、以下で計算されます。
 
 * Limit の場合は角度を 180 で割り、その係数を以って乗算
   * 0 の場合は Stiffness と DragForce を無効化
-* Immobile の場合は Stiffness と DragForce に 1:1 の割合で加算
-  * Limit がある場合は先の係数を以って乗算
+* Immobile の場合は条件分岐により変化
+  * 「Immobile Type が `World (Experimental)` かつ Immobile が 1.0 であること」に該当する場合
+    * スプリングボーンのセンターにヒューマノイドの Hips ボーンを設定する形で擬似的に実装
+  * 該当しない場合は Stiffness と DragForce に 1:1 の割合で加算
+    * Limit がある場合は先の係数を以って乗算
 
 VRM Spring Bone と VRC PhysBone は計算方法が異なるため結果は同一になりません。また VRM Spring Bone の仕様に存在しない以下の項目には変換に対応していません。
 


### PR DESCRIPTION
## Summary

This PR changes to pseudo-implement Immobile when specific conditions are met.

## Details

When "Immobile Type is `World (Experimental)` and Immobile is 1.0", this is pseudo-implemented by setting the humanoid Hips bone as the spring bone center. By setting the Hips bone as the spring bone center, the movement amount can theoretically be reduced to zero by subtracting the center bone's movement, making it literally immobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VRChat PhysBone to VRM Spring Bone conversion for immobile physics configurations using World-type settings, now applying more accurate center bone positioning.

* **Documentation**
  * Updated compatibility documentation regarding immobile and limit parameter handling during physics bone conversion processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->