### PR TITLE
[exporter] Improve blend shape list retrieval

### DIFF
--- a/Editor/NDMFVRMExporter.asmdef
+++ b/Editor/NDMFVRMExporter.asmdef
@@ -6,6 +6,7 @@
         "GUID:fe747755f7b44e048820525b07f9b956",
         "GUID:901e56b065a857d4483a77f8cae73588",
         "GUID:fc900867c0f47cd49b6e2ae4ef907300",
+        "GUID:5ce33783346c3124990afbe7b0390a06",
         "GUID:ac4815c6727e4e34b9e13bb042cbc029",
         "GUID:1361f424038d2644fa9897816cda865f",
         "GUID:e7f0f8dffe955d640bbc76d1d4f4986e",

--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -24,7 +24,7 @@ using Object = UnityEngine.Object;
 
 #if NVE_HAS_VRCHAT_AVATAR_SDK
 using System.Net.Http;
-using System.Text;
+using System.Reflection;
 using System.Threading;
 using VRC.Core;
 using VRC.Dynamics;
@@ -890,6 +890,9 @@ namespace com.github.hkrn
         [NotKeyable] [SerializeField] internal bool isBinary;
         [NotKeyable] [SerializeField] internal bool isPreset;
 
+        // from 1.3.0
+        [NotKeyable] [SerializeField] internal SkinnedMeshRenderer? skinnedMeshRenderer;
+
         internal const string BlendShapeNamePrefix = "blendShape.";
 
         internal enum BaseType
@@ -932,18 +935,28 @@ namespace com.github.hkrn
 
         internal void SetFromMmdExpression(string targetName)
         {
-            var blendShapeNames = new List<string>();
             if (!gameObject || !gameObject!.transform)
             {
                 return;
             }
 
-            RetrieveAllBlendShapes(gameObject.transform, ref blendShapeNames);
-            var index = blendShapeNames.IndexOf(targetName);
-            if (index == -1)
+            var blendShapeNames = new List<string>();
+            SkinnedMeshRenderer? foundSkinnedMeshRenderer = null;
+            RetrieveAllBlendShapes(gameObject.transform, (name, innerSkinnedMeshRenderer, _) =>
+                {
+                    if (name == targetName)
+                    {
+                        foundSkinnedMeshRenderer = innerSkinnedMeshRenderer;
+                    }
+                },
+                ref blendShapeNames);
+            if (!foundSkinnedMeshRenderer)
+            {
                 return;
+            }
+
+            skinnedMeshRenderer = foundSkinnedMeshRenderer;
             baseType = BaseType.BlendShape;
-            blendShapeName = blendShapeNames[index];
             overrideBlink = vrm.core.ExpressionOverrideType.Block;
             overrideLookAt = vrm.core.ExpressionOverrideType.Block;
             overrideMouth = vrm.core.ExpressionOverrideType.Block;
@@ -958,21 +971,25 @@ namespace com.github.hkrn
         internal static void RetrieveAllBlendShapes<T>(Transform transform,
             Action<string, SkinnedMeshRenderer, T> callback, ref T blendShapeNames)
         {
+            if (!transform)
+            {
+                return;
+            }
+            if (transform.TryGetComponent<SkinnedMeshRenderer>(out var parentSmr))
+            {
+                var parentMesh = parentSmr.sharedMesh;
+                if (parentMesh)
+                {
+                    var numBlendShapes = parentMesh.blendShapeCount;
+                    for (var j = 0; j < numBlendShapes; j++)
+                    {
+                        callback(parentMesh.GetBlendShapeName(j), parentSmr, blendShapeNames);
+                    }
+                }
+            }
             for (var i = 0; i < transform.childCount; i++)
             {
                 var child = transform.GetChild(i);
-                if (!child || child is null || !child.TryGetComponent<SkinnedMeshRenderer>(out var smr))
-                    continue;
-                var mesh = smr.sharedMesh;
-                if (mesh)
-                {
-                    var numBlendShapes = mesh.blendShapeCount;
-                    for (var j = 0; j < numBlendShapes; j++)
-                    {
-                        callback(mesh.GetBlendShapeName(j), smr, blendShapeNames);
-                    }
-                }
-
                 RetrieveAllBlendShapes(child, callback, ref blendShapeNames);
             }
         }
@@ -1025,22 +1042,58 @@ namespace com.github.hkrn
                 {
                     var gameObjectProp = property.FindPropertyRelative(nameof(VrmExpressionProperty.gameObject));
                     var gameObject = (GameObject)gameObjectProp.objectReferenceValue;
-                    if (_blendShapeNames.Count == 0 && gameObject)
+                    var skinnedMeshRendererProp = property.FindPropertyRelative(nameof(VrmExpressionProperty.skinnedMeshRenderer));
+                    var skinnedMeshRenderer = (SkinnedMeshRenderer)skinnedMeshRendererProp.objectReferenceValue;
+                    var transform = skinnedMeshRenderer ? skinnedMeshRenderer.transform : gameObject.transform;
+                    var blendShapeName = property.FindPropertyRelative(nameof(VrmExpressionProperty.blendShapeName));
+
+                    if (_blendShapeNames.Count == 0 && transform)
                     {
-                        VrmExpressionProperty.RetrieveAllBlendShapes(gameObject.transform, ref _blendShapeNames);
+                        VrmExpressionProperty.RetrieveAllBlendShapes(transform, ref _blendShapeNames);
                     }
 
-                    var blendShapeName = property.FindPropertyRelative(nameof(VrmExpressionProperty.blendShapeName));
+                    EditorGUI.ObjectField(fieldRect, skinnedMeshRendererProp);
+                    fieldRect.y += fieldRect.height;
+
                     var selectedIndex = blendShapeName.stringValue != null
                         ? _blendShapeNames.IndexOf(blendShapeName.stringValue)
                         : -1;
                     var newIndex = EditorGUI.Popup(fieldRect, selectedIndex, _blendShapeNames.ToArray());
+                    fieldRect.y += fieldRect.height;
+
                     if (newIndex >= 0 && newIndex < _blendShapeNames.Count)
                     {
                         var targetBlendShapeName = _blendShapeNames[newIndex];
                         blendShapeName.stringValue = targetBlendShapeName;
                     }
-
+#if NVE_HAS_MODULAR_AVATAR
+                    if (GUI.Button(fieldRect, "Select"))
+                    {
+                        const BindingFlags bindingAttrPrivate = BindingFlags.NonPublic | BindingFlags.Instance;
+                        var assembly = typeof(nadena.dev.modular_avatar.core.editor.AvatarProcessor).Assembly;
+                        var blendShapeSelectWindow =
+                            assembly.GetType("nadena.dev.modular_avatar.core.editor.BlendshapeSelectWindow");
+                        if (_window)
+                        {
+                            Object.DestroyImmediate(_window);
+                            _window = null;
+                        }
+                        _window = ScriptableObject.CreateInstance(blendShapeSelectWindow);
+                        blendShapeSelectWindow.GetField("AvatarRoot", bindingAttrPrivate)!.SetValue(_window,
+                            gameObject);
+                        blendShapeSelectWindow.GetField("OfferBinding", bindingAttrPrivate)!.SetValue(_window,
+                            (Action<nadena.dev.modular_avatar.core.BlendshapeBinding>)OfferBinding);
+                        blendShapeSelectWindow.GetMethod("Show", new Type[] { })!.Invoke(_window, null);
+                        void OfferBinding(nadena.dev.modular_avatar.core.BlendshapeBinding binding)
+                        {
+                            var component = gameObject.GetComponent<NdmfVrmExporterComponent>();
+                            var referenceObject = binding.ReferenceMesh.Get(component);
+                            skinnedMeshRendererProp.objectReferenceValue = referenceObject.GetComponent<SkinnedMeshRenderer>();
+                            blendShapeName.stringValue = binding.Blendshape;
+                            property.serializedObject.ApplyModifiedProperties();
+                        }
+                    }
+#endif // NVE_HAS_MODULAR_AVATAR
                     break;
                 }
                 case VrmExpressionProperty.BaseType.AnimationClip:
@@ -1101,10 +1154,30 @@ namespace com.github.hkrn
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
-            var height = LineHeight * 3;
+            var height = LineHeight;
             if (!property.FindPropertyRelative(nameof(VrmExpressionProperty.isPreset)).boolValue)
             {
                 height += LineHeight;
+            }
+
+            switch ((VrmExpressionProperty.BaseType)property.FindPropertyRelative(nameof(VrmExpressionProperty.baseType)).intValue)
+            {
+                case VrmExpressionProperty.BaseType.BlendShape:
+                {
+#if NVE_HAS_MODULAR_AVATAR
+                    height += LineHeight * 4;
+#else
+                    height += LineHeight * 3;
+#endif // NVE_HAS_MODULAR_AVATAR
+                    break;
+                }
+                case VrmExpressionProperty.BaseType.AnimationClip:
+                {
+                    height += LineHeight * 2;
+                    break;
+                }
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
 
             if (property.FindPropertyRelative(nameof(VrmExpressionProperty.optionsFoldout)).boolValue)
@@ -1118,6 +1191,7 @@ namespace com.github.hkrn
         private float LineHeight => EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
 
         private List<string> _blendShapeNames = new();
+        private ScriptableObject? _window;
     }
 
     internal sealed class MaterialVariantMapping
@@ -1411,6 +1485,7 @@ namespace com.github.hkrn
             {
                 return (uint)ex.HResult is 0x80070050 or 0x800700B7;
             }
+
             var randomFilename = Path.GetRandomFileName();
             var tempFilePath = $"{filePath}.{randomFilename}.tmp";
             var backupFilePath = $"{filePath}.{randomFilename}.bak";
@@ -1424,6 +1499,7 @@ namespace com.github.hkrn
                 {
                     /* ignore only when file is already exists */
                 }
+
                 File.WriteAllBytes(tempFilePath, data);
                 File.Replace(tempFilePath, filePath, backupFilePath);
             }
@@ -1433,6 +1509,7 @@ namespace com.github.hkrn
                 {
                     File.Delete(backupFilePath);
                 }
+
                 if (File.Exists(tempFilePath))
                 {
                     File.Delete(tempFilePath);

--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -956,6 +956,7 @@ namespace com.github.hkrn
             }
 
             skinnedMeshRenderer = foundSkinnedMeshRenderer;
+            blendShapeName = targetName;
             baseType = BaseType.BlendShape;
             overrideBlink = vrm.core.ExpressionOverrideType.Block;
             overrideLookAt = vrm.core.ExpressionOverrideType.Block;
@@ -975,6 +976,7 @@ namespace com.github.hkrn
             {
                 return;
             }
+
             if (transform.TryGetComponent<SkinnedMeshRenderer>(out var parentSmr))
             {
                 var parentMesh = parentSmr.sharedMesh;
@@ -987,6 +989,7 @@ namespace com.github.hkrn
                     }
                 }
             }
+
             for (var i = 0; i < transform.childCount; i++)
             {
                 var child = transform.GetChild(i);
@@ -1042,11 +1045,13 @@ namespace com.github.hkrn
                 {
                     var gameObjectProp = property.FindPropertyRelative(nameof(VrmExpressionProperty.gameObject));
                     var gameObject = (GameObject)gameObjectProp.objectReferenceValue;
-                    var skinnedMeshRendererProp = property.FindPropertyRelative(nameof(VrmExpressionProperty.skinnedMeshRenderer));
+                    var skinnedMeshRendererProp =
+                        property.FindPropertyRelative(nameof(VrmExpressionProperty.skinnedMeshRenderer));
                     var skinnedMeshRenderer = (SkinnedMeshRenderer)skinnedMeshRendererProp.objectReferenceValue;
                     var transform = skinnedMeshRenderer ? skinnedMeshRenderer.transform : gameObject.transform;
                     var blendShapeName = property.FindPropertyRelative(nameof(VrmExpressionProperty.blendShapeName));
 
+                    StaleAllBlendShapeNamesIfChanged(transform);
                     if (_blendShapeNames.Count == 0 && transform)
                     {
                         VrmExpressionProperty.RetrieveAllBlendShapes(transform, ref _blendShapeNames);
@@ -1073,22 +1078,43 @@ namespace com.github.hkrn
                         var assembly = typeof(nadena.dev.modular_avatar.core.editor.AvatarProcessor).Assembly;
                         var blendShapeSelectWindow =
                             assembly.GetType("nadena.dev.modular_avatar.core.editor.BlendshapeSelectWindow");
+                        if (blendShapeSelectWindow == null)
+                        {
+                            EditorUtility.DisplayDialog("Select button is unavailable",
+                                "Select button is unavailable due to BlendshapeSelectWindow is unavailable", "OK");
+                            Debug.LogWarning("BlendshapeSelectWindow is unavailable and will be skipped");
+                            break;
+                        }
+
+                        var avatarRoot = blendShapeSelectWindow.GetField("AvatarRoot", bindingAttrPrivate);
+                        var offerBinding = blendShapeSelectWindow.GetField("OfferBinding", bindingAttrPrivate);
+                        var show = blendShapeSelectWindow.GetMethod("Show", new Type[] { });
+                        if (avatarRoot == null || offerBinding == null || show == null)
+                        {
+                            EditorUtility.DisplayDialog("Select button is unavailable",
+                                "Select button is unavailable due to BlendshapeSelectWindow API is changed", "OK");
+                            Debug.LogWarning("BlendshapeSelectWindow API is changed and will be skipped");
+                            break;
+                        }
+
                         if (_window)
                         {
                             Object.DestroyImmediate(_window);
                             _window = null;
                         }
+
                         _window = ScriptableObject.CreateInstance(blendShapeSelectWindow);
-                        blendShapeSelectWindow.GetField("AvatarRoot", bindingAttrPrivate)!.SetValue(_window,
-                            gameObject);
-                        blendShapeSelectWindow.GetField("OfferBinding", bindingAttrPrivate)!.SetValue(_window,
+                        avatarRoot.SetValue(_window, gameObject);
+                        offerBinding.SetValue(_window,
                             (Action<nadena.dev.modular_avatar.core.BlendshapeBinding>)OfferBinding);
-                        blendShapeSelectWindow.GetMethod("Show", new Type[] { })!.Invoke(_window, null);
+                        show.Invoke(_window, null);
+
                         void OfferBinding(nadena.dev.modular_avatar.core.BlendshapeBinding binding)
                         {
                             var component = gameObject.GetComponent<NdmfVrmExporterComponent>();
                             var referenceObject = binding.ReferenceMesh.Get(component);
-                            skinnedMeshRendererProp.objectReferenceValue = referenceObject.GetComponent<SkinnedMeshRenderer>();
+                            skinnedMeshRendererProp.objectReferenceValue =
+                                referenceObject.GetComponent<SkinnedMeshRenderer>();
                             blendShapeName.stringValue = binding.Blendshape;
                             property.serializedObject.ApplyModifiedProperties();
                         }
@@ -1160,7 +1186,8 @@ namespace com.github.hkrn
                 height += LineHeight;
             }
 
-            switch ((VrmExpressionProperty.BaseType)property.FindPropertyRelative(nameof(VrmExpressionProperty.baseType)).intValue)
+            switch ((VrmExpressionProperty.BaseType)property
+                        .FindPropertyRelative(nameof(VrmExpressionProperty.baseType)).intValue)
             {
                 case VrmExpressionProperty.BaseType.BlendShape:
                 {
@@ -1188,10 +1215,23 @@ namespace com.github.hkrn
             return height;
         }
 
+        private void StaleAllBlendShapeNamesIfChanged(Transform transform)
+        {
+            var sourceId = transform ? transform.GetInstanceID() : 0;
+            if (sourceId == _lastTransformInstanceId)
+            {
+                return;
+            }
+
+            _blendShapeNames.Clear();
+            _lastTransformInstanceId = sourceId;
+        }
+
         private float LineHeight => EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
 
         private List<string> _blendShapeNames = new();
         private ScriptableObject? _window;
+        private int _lastTransformInstanceId;
     }
 
     internal sealed class MaterialVariantMapping


### PR DESCRIPTION
## Summary

This PR improves blend shape list retrieval.

## Details

When Modular Avatar is installed, add a `Select` button below the blend shape list screen and improve blend shape list retrieval by utilizing `BlendshapeSelectWindow`, an internal class of Modular Avatar. Works as before if unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to select and assign specific mesh renderers to blendshape-based VRM expressions
  * Added optional integration with Modular Avatar for simplified blendshape selection

* **Improvements**
  * Enhanced blendshape detection with improved stability and null-safety checks
  * Upgraded editor interface for VRM expression blendshape selection with better caching and display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->