### PR TITLE
[exporter] Implemented `VRMC_springBone_limit`

### DIFF
--- a/Editor/Document.cs
+++ b/Editor/Document.cs
@@ -3486,6 +3486,48 @@ namespace com.github.hkrn.vrm.sb
         public JToken? Extras { get; set; }
     }
 
+    public sealed class ConeLimit
+    {
+        public float Angle { get; set; }
+        public Quaternion Rotation { get; set; } = Quaternion.Identity;
+        public IExtensions? Extensions { get; set; }
+        public JToken? Extras { get; set; }
+    }
+
+    public sealed class HingeLimit
+    {
+        public float Angle { get; set; }
+        public Quaternion Rotation { get; set; } = Quaternion.Identity;
+        public IExtensions? Extensions { get; set; }
+        public JToken? Extras { get; set; }
+    }
+
+    public sealed class SphericalLimit
+    {
+        public float Pitch { get; set; }
+        public float Yaw { get; set; }
+        public Quaternion Rotation { get; set; } = Quaternion.Identity;
+        public IExtensions? Extensions { get; set; }
+        public JToken? Extras { get; set; }
+    }
+
+    public sealed class Limit
+    {
+        public ConeLimit? Cone { get; set; }
+        public HingeLimit? Hinge { get; set; }
+        public SphericalLimit? Spherical { get; set; }
+        public IExtensions? Extensions { get; set; }
+        public JToken? Extras { get; set; }
+    }
+
+    public sealed class SpringLimit
+    {
+        public string SpecVersion { get; set; } = "1.0";
+        public Limit Limit { get; set; } = new Limit();
+        public IExtensions? Extensions { get; set; }
+        public JToken? Extras { get; set; }
+    }
+
     public sealed class Spring
     {
         public gltf.ObjectID? Center { get; set; }
@@ -3760,6 +3802,11 @@ namespace com.github.hkrn.vrm
         public static JToken SaveAsNode(sb.ExtendedCollider collider)
         {
             return JToken.FromObject(collider, JsonSerializer.Create(SerializerOptions));
+        }
+
+        public static JToken SaveAsNode(sb.SpringLimit limit)
+        {
+            return JToken.FromObject(limit, JsonSerializer.Create(SerializerOptions));
         }
 
         public static JToken SaveAsNode(constraint.NodeConstraint nodeConstraint)

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -250,6 +250,9 @@ msgstr "Exporting all VRM animations has been completed!"
 msgid "component.validation.animation.non-humanoid"
 msgstr "Animation clip contains non-humanoid motion. It will be ignored and not exported."
 
+msgid "component.spring-bone.experimental-enable-limit"
+msgstr "(Experimental) Enable Spring Bone Limit Extension"
+
 msgid "component.debug.make-all-node-names-unique"
 msgstr "Make All Node Names Unique"
 

--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -175,12 +175,16 @@ namespace com.github.hkrn
 
         [NotKeyable] [SerializeField] internal List<AnimationClip> humanoidAnimations = new();
 
+        [NotKeyable] [SerializeField] internal bool experimentalEnableSpringBoneLimit;
+
         public bool HasAuthor => authors.Count > 0 && !string.IsNullOrWhiteSpace(authors.First());
 
         public bool HasLicenseUrl =>
             !string.IsNullOrWhiteSpace(licenseUrl) && Uri.TryCreate(licenseUrl, UriKind.Absolute, out _);
 
         public bool HasAvatarRoot => RuntimeUtil.IsAvatarRoot(gameObject.transform);
+
+        public bool IsSpringBoneLimitEnabled => experimentalEnableSpringBoneLimit;
 
         // ReSharper disable once Unity.RedundantEventFunction
         private void Start()
@@ -240,7 +244,6 @@ namespace com.github.hkrn
         private SerializedProperty _deleteTemporaryObjectsProp = null!;
         private SerializedProperty _ktxToolPathProp = null!;
         private SerializedProperty _metadataModeSelection = null!;
-
         private SerializedProperty _expressionModeSelection = null!;
 
         // from 1.1.0
@@ -250,6 +253,8 @@ namespace com.github.hkrn
         // from 1.3.0
         private SerializedProperty _animationFoldoutProp = null!;
         private SerializedProperty _humanoidAnimationsProp = null!;
+        private SerializedProperty _experimentalEnableSpringBoneLimit = null!;
+
 #if NVE_HAS_VRCHAT_AVATAR_SDK
         private struct VRChatAvatarToMetadata
         {
@@ -324,6 +329,8 @@ namespace com.github.hkrn
                 serializedObject.FindProperty(nameof(NdmfVrmExporterComponent.excludedSpringBoneColliderTransforms));
             _excludedSpringBoneTransformsProp =
                 serializedObject.FindProperty(nameof(NdmfVrmExporterComponent.excludedSpringBoneTransforms));
+            _experimentalEnableSpringBoneLimit =
+                serializedObject.FindProperty(nameof(NdmfVrmExporterComponent.experimentalEnableSpringBoneLimit));
             _constraintFoldoutProp = serializedObject.FindProperty(nameof(NdmfVrmExporterComponent.constraintFoldout));
             _excludedConstraintTransformsProp =
                 serializedObject.FindProperty(nameof(NdmfVrmExporterComponent.excludedConstraintTransforms));
@@ -844,6 +851,7 @@ namespace com.github.hkrn
             EditorGUILayout.PropertyField(_excludedSpringBoneTransformsProp,
                 new GUIContent(Translator._("component.spring-bone.exclude.bones")));
             EditorGUI.indentLevel--;
+            DrawToggleLeft(Translator._("component.spring-bone.experimental-enable-limit"), _experimentalEnableSpringBoneLimit);
         }
 
         private void DrawConstraintOptions()
@@ -1410,6 +1418,7 @@ namespace com.github.hkrn
         private static readonly string VrmcSpringBoneExtendedCollider = "VRMC_springBone_extended_collider";
         private static readonly string VrmcNodeConstraint = "VRMC_node_constraint";
         private static readonly string VrmcMaterialsMtoon = "VRMC_materials_mtoon";
+        private static readonly string VrmcSpringBoneLimit = "VRMC_springBone_limit";
         private static readonly int PropertyCull = Shader.PropertyToID("_Cull");
         private static readonly int PropertyUseEmission = Shader.PropertyToID("_UseEmission");
         private static readonly int PropertyEmissionMainStrength = Shader.PropertyToID("_EmissionMainStrength");
@@ -2626,7 +2635,7 @@ namespace com.github.hkrn
                     var bones = transform.GetComponents<VRCPhysBone>();
                     foreach (var bone in bones!)
                     {
-                        ConvertSpringBone(bone, immutablePbColliders, immutableColliderGroups, ref springs);
+                        ConvertSpringBone(bone, component, immutablePbColliders, immutableColliderGroups, ref springs);
                     }
                 }
 #endif // NVE_HAS_VRCHAT_AVATAR_SDK
@@ -4015,7 +4024,19 @@ namespace com.github.hkrn
                 return numChildren > 0;
             }
 
-            private static (int, int) FindTransformDepth(Transform? transform, Transform? root)
+            private readonly struct DepthRatio
+            {
+                public DepthRatio(float upperDepth, float lowerDepth)
+                {
+                    var totalDepth = upperDepth + lowerDepth;
+                    var depthRatio = totalDepth != 0 ? upperDepth / totalDepth : 0;
+                    Value = depthRatio;
+                }
+
+                public float Value { get; }
+            }
+
+            private static DepthRatio FindTransformDepth(Transform? transform, Transform? root)
             {
                 var upperDepth = 0;
                 var upperTransform = transform;
@@ -4031,10 +4052,10 @@ namespace com.github.hkrn
                     lowerDepth++;
                 }
 
-                return (upperDepth, lowerDepth);
+                return new DepthRatio(upperDepth, lowerDepth);
             }
 
-            private void ConvertSpringBone(VRCPhysBone pb, IImmutableList<VRCPhysBoneColliderBase> pbColliders,
+            private void ConvertSpringBone(VRCPhysBone pb, NdmfVrmExporterComponent component, IImmutableList<VRCPhysBoneColliderBase> pbColliders,
                 IImmutableList<vrm.sb.ColliderGroup> colliderGroups, ref IList<vrm.sb.Spring> springs)
             {
                 var rootTransform = pb.GetRootTransform();
@@ -4054,23 +4075,20 @@ namespace com.github.hkrn
                         case true when pb.multiChildType == VRCPhysBoneBase.MultiChildType.Ignore && index == 1:
                         {
                             var name = $"{pb.name}.{index}";
-                            ConvertSpringBoneInner(pb, name, transforms.Skip(1).ToImmutableList(),
-                                pbColliders,
+                            ConvertSpringBoneInner(pb, component, name, transforms.Skip(1).ToImmutableList(), pbColliders,
                                 colliderGroups, ref springs);
                             break;
                         }
                         case true:
                         {
                             var name = $"{pb.name}.{index}";
-                            ConvertSpringBoneInner(pb, name, transforms, pbColliders, colliderGroups,
-                                ref springs);
+                            ConvertSpringBoneInner(pb, component, name, transforms, pbColliders, colliderGroups, ref springs);
                             break;
                         }
                         default:
                         {
                             var name = pb.name;
-                            ConvertSpringBoneInner(pb, name, transforms, pbColliders, colliderGroups,
-                                ref springs);
+                            ConvertSpringBoneInner(pb, component, name, transforms, pbColliders, colliderGroups, ref springs);
                             break;
                         }
                     }
@@ -4079,7 +4097,7 @@ namespace com.github.hkrn
                 }
             }
 
-            private void ConvertSpringBoneInner(VRCPhysBone pb, string name, IImmutableList<Transform> transforms,
+            private void ConvertSpringBoneInner(VRCPhysBone pb, NdmfVrmExporterComponent component, string name, IImmutableList<Transform> transforms,
                 IImmutableList<VRCPhysBoneColliderBase> pbColliders,
                 IImmutableList<vrm.sb.ColliderGroup> colliderGroups, ref IList<vrm.sb.Spring> springs)
             {
@@ -4101,22 +4119,16 @@ namespace com.github.hkrn
                             return null;
                         }
 
-                        var (upperDepth, lowerDepth) = FindTransformDepth(transform, rootTransform);
-                        var totalDepth = upperDepth + lowerDepth;
-                        var depthRatio = totalDepth != 0 ? upperDepth / (float)totalDepth : 0;
-                        var evaluate = new Func<float, AnimationCurve, float>((value, curve) =>
-                            curve is { length: > 0 }
-                                ? curve.Evaluate(depthRatio) * value
-                                : value);
-                        var gravity = evaluate(pb.gravity, pb.gravityCurve);
-                        var stiffness = evaluate(pb.stiffness, pb.stiffnessCurve);
-                        var hitRadius = evaluate(pb.radius, pb.radiusCurve);
-                        var pull = evaluate(pb.pull, pb.pullCurve);
-                        var immobile = evaluate(pb.immobile, pb.immobileCurve) * 0.5f;
+                        var depthRatio = FindTransformDepth(transform, rootTransform);
+                        var gravity = EvaluateCurve(pb.gravityCurve, pb.gravity, depthRatio);
+                        var stiffness = EvaluateCurve(pb.stiffnessCurve, pb.stiffness, depthRatio);
+                        var hitRadius = EvaluateCurve(pb.radiusCurve, pb.radius, depthRatio);
+                        var pull = EvaluateCurve(pb.pullCurve, pb.pull, depthRatio);
+                        var immobile = EvaluateCurve(pb.immobileCurve, pb.immobile, depthRatio) * 0.5f;
                         float stiffnessFactor, pullFactor;
                         if (pb.limitType != VRCPhysBoneBase.LimitType.None && !centerNode.HasValue)
                         {
-                            var maxAngleX = evaluate(pb.maxAngleX, pb.maxAngleXCurve);
+                            var maxAngleX = EvaluateCurve(pb.maxAngleXCurve, pb.maxAngleX, depthRatio);
                             stiffnessFactor = maxAngleX > 0.0f ? 1.0f / Mathf.Clamp01(maxAngleX / 180.0f) : 0.0f;
                             pullFactor = stiffnessFactor * 0.5f;
                         }
@@ -4126,7 +4138,7 @@ namespace com.github.hkrn
                             pullFactor = 1.0f;
                         }
 
-                        return new vrm.sb.Joint
+                        var joint = new vrm.sb.Joint
                         {
                             Node = nodeID.Value,
                             HitRadius = hitRadius,
@@ -4135,6 +4147,21 @@ namespace com.github.hkrn
                             GravityDir = -System.Numerics.Vector3.UnitY,
                             DragForce = Mathf.Clamp01(immobile + pull * pullFactor),
                         };
+                        var limit = component.IsSpringBoneLimitEnabled ? ConvertSpringLimit(pb, depthRatio) : null;
+                        if (limit == null)
+                        {
+                            return joint;
+                        }
+
+                        joint.Extensions ??= new Dictionary<string, JToken>();
+                        joint.Extensions.Add(VrmcSpringBoneLimit, vrm.Document.SaveAsNode(new vrm.sb.SpringLimit
+                        {
+                            SpecVersion = "1.0-draft",
+                            Limit = limit,
+                        }));
+                        _extensionUsed.Add(VrmcSpringBoneLimit);
+
+                        return joint;
                     })
                     .ToList();
                 var colliders = (from pbCollider in pb.colliders
@@ -4163,6 +4190,63 @@ namespace com.github.hkrn
                     Joints = joints.Where(joint => joint != null).Select(joint => joint!).ToList(),
                 };
                 springs.Add(spring);
+            }
+
+            private static vrm.sb.Limit? ConvertSpringLimit(VRCPhysBone pb, DepthRatio depthRatio)
+            {
+                vrm.sb.Limit? limit = null;
+                switch (pb.limitType)
+                {
+                    case VRCPhysBoneBase.LimitType.Angle:
+                    {
+                        limit = new vrm.sb.Limit
+                        {
+                            Cone = new vrm.sb.ConeLimit
+                            {
+                                Angle = Mathf.Deg2Rad * EvaluateCurve(pb.maxAngleXCurve, pb.maxAngleX, depthRatio),
+                                Rotation = Quaternion.Euler(pb.limitRotation).ToQuaternionWithCoordinateSpace(),
+                            }
+                        };
+                        break;
+                    }
+                    case VRCPhysBoneBase.LimitType.Hinge:
+                    {
+                        limit = new vrm.sb.Limit
+                        {
+                            Hinge = new vrm.sb.HingeLimit
+                            {
+                                Angle = Mathf.Deg2Rad * EvaluateCurve(pb.maxAngleXCurve, pb.maxAngleX, depthRatio),
+                                Rotation = Quaternion.Euler(pb.limitRotation).ToQuaternionWithCoordinateSpace(),
+                            }
+                        };
+                        break;
+                    }
+                    case VRCPhysBoneBase.LimitType.Polar:
+                    {
+                        limit = new vrm.sb.Limit
+                        {
+                            Spherical = new vrm.sb.SphericalLimit
+                            {
+                                Pitch = EvaluateCurve(pb.maxAngleXCurve, pb.maxAngleX, depthRatio),
+                                Yaw = EvaluateCurve(pb.maxAngleZCurve, pb.maxAngleZ, depthRatio),
+                                Rotation = Quaternion.Euler(pb.limitRotation).ToQuaternionWithCoordinateSpace(),
+                            }
+                        };
+                        break;
+                    }
+                    case VRCPhysBoneBase.LimitType.None:
+                    default:
+                    {
+                        break;
+                    }
+                }
+
+                return limit;
+            }
+
+            private static float EvaluateCurve(AnimationCurve curve, float value, DepthRatio depthRatio)
+            {
+                return curve is { length: > 0 } ? curve.Evaluate(depthRatio.Value) * value : value;
             }
 #endif // NVE_HAS_VRCHAT_AVATAR_SDK
 

--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -4227,8 +4227,8 @@ namespace com.github.hkrn
                         {
                             Spherical = new vrm.sb.SphericalLimit
                             {
-                                Pitch = EvaluateCurve(pb.maxAngleXCurve, pb.maxAngleX, depthRatio),
-                                Yaw = EvaluateCurve(pb.maxAngleZCurve, pb.maxAngleZ, depthRatio),
+                                Pitch = Mathf.Deg2Rad * EvaluateCurve(pb.maxAngleXCurve, pb.maxAngleX, depthRatio),
+                                Yaw = Mathf.Deg2Rad * EvaluateCurve(pb.maxAngleZCurve, pb.maxAngleZ, depthRatio),
                                 Rotation = Quaternion.Euler(pb.limitRotation).ToQuaternionWithCoordinateSpace(),
                             }
                         };

--- a/docs~/compatibility.md
+++ b/docs~/compatibility.md
@@ -11,7 +11,7 @@
 > [!NOTE]
 > VRC PhysBone が登場する前に使われていた [Dynamic Bone](https://assetstore.unity.com/packages/tools/animation/dynamic-bone-16743) からの変換には対応していません
 
-VRC PhysBone については VRM Spring Bone のジョイントに変換されます。ただし Immobile および Limit については VRM Spring Bone に直接対応する仕様が存在しないため、`Enable Spring Bone Limit` を無効にしている場合に限り「動きにくくする措置」として以下で計算されます。
+VRC PhysBone については VRM Spring Bone のジョイントに変換されます。ただし Immobile および Limit については VRM Spring Bone に直接対応する仕様が存在しないため、`(Experimental) Enable Spring Bone Limit` を無効にしている場合に限り「動きにくくする措置」として以下で計算されます。
 
 * Limit の場合は角度を 180 で割り、その係数を以って乗算
   * 0 の場合は Stiffness と DragForce を無効化

--- a/docs~/compatibility.md
+++ b/docs~/compatibility.md
@@ -11,7 +11,7 @@
 > [!NOTE]
 > VRC PhysBone が登場する前に使われていた [Dynamic Bone](https://assetstore.unity.com/packages/tools/animation/dynamic-bone-16743) からの変換には対応していません
 
-VRC PhysBone については VRM Spring Bone のジョイントに変換されます。ただし Immobile および Limit については VRM Spring Bone に直接対応する仕様が存在しないため、以下で計算されます。
+VRC PhysBone については VRM Spring Bone のジョイントに変換されます。ただし Immobile および Limit については VRM Spring Bone に直接対応する仕様が存在しないため、`Enable Spring Bone Limit` を無効にしている場合に限り「動きにくくする措置」として以下で計算されます。
 
 * Limit の場合は角度を 180 で割り、その係数を以って乗算
   * 0 の場合は Stiffness と DragForce を無効化
@@ -46,7 +46,19 @@ VRC PhysBone のコライダーは以下の三種類に対応しています。
 * `Plain` (平面)
 * `Sphere` (球)
 
-`Inside Bounds` が有効もしくは `Plain` の場合は `VRMC_springBone_extended_collider` 拡張に対応しているアプリケーションが必要となります。対応していないアプリケーションを利用した場合は前者が存在しないものとして、後者の場合は半径 10km の巨大スフィアコライダーを設定する形でそれぞれ処理されます。
+`Inside Bounds` が有効もしくは `Plain` の場合は [VRMC_springBone_extended_collider](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_springBone_extended_collider-1.0/README.ja.md) 拡張に対応しているアプリケーションが必要となります。対応していないアプリケーションを利用した場合は前者が存在しないものとして、後者の場合は半径 10km の巨大スフィアコライダーを設定する形でそれぞれ処理されます。
+
+`(Experimental) Enable Spring Bone Limit Extension` を有効にしている場合は VRC PhysBone の角度制限を [VRMC_springBone_limit](https://github.com/vrm-c/vrm-specification/pull/496) に移植します。VRC PhysBone の角度制限のうち以下の種別に対応しており、ほぼ同じ形で移植されます。
+
+* `Angle`
+  * `Cone` として移植
+* `Hinge`
+  * `Hinge` そのまま
+* `Polar`
+  * `Spherical` として移植
+  * `Max Angle` を Pitch に、`Max Yaw` を Yaw にコピー
+
+`VRMC_springBone_limit` 未対応のアプリケーションで読み込まれた場合は単にスプリングボーンに対する角度制限が行われません。
 
 ## Constraint の変換
 

--- a/docs~/component.md
+++ b/docs~/component.md
@@ -192,7 +192,7 @@ MMD 互換のブレンドシェイプが存在する場合は `Set Preset Expres
 
 スプリングボーンに可動域となる角度制限を付与する拡張仕様である [VRMC_springBone_limit](https://github.com/vrm-c/vrm-specification/pull/496) 拡張を有効にします。有効にすると VRC PhysBone の角度制限の設定を移植する形で反映されます。詳細は「Spring Bone の変換」を確認してください。
 
-UniVRM 0.131 以降で利用可能ですが、実装時点ではまだ仕様が正式のものではなくあくまで草稿のため既定では無効となっています。
+UniVRM 0.130 以降で利用可能ですが、実装時点 (2026/5/31) ではまだ仕様が正式のものではなくあくまで草稿のため既定では無効となっています。
 
 ## Constraint Options
 

--- a/docs~/component.md
+++ b/docs~/component.md
@@ -188,6 +188,12 @@ MMD 互換のブレンドシェイプが存在する場合は `Set Preset Expres
 
 ビルド時に非表示のゲームオブジェクトがある場合は出力から除外しますが、この項目を使うことによってゲームオブジェクトを非表示に設定しなくても出力を除外することが可能になります。
 
+* `(Experimental) Enable Spring Bone Limit Extension`
+
+スプリングボーンに可動域となる角度制限を付与する拡張仕様である [VRMC_springBone_limit](https://github.com/vrm-c/vrm-specification/pull/496) 拡張を有効にします。有効にすると VRC PhysBone の角度制限の設定を移植する形で反映されます。詳細は「Spring Bone の変換」を確認してください。
+
+UniVRM 0.131 以降で利用可能ですが、実装時点ではまだ仕様が正式のものではなくあくまで草稿のため既定では無効となっています。
+
 ## Constraint Options
 
 ビルド時にのみ除外する VRC PhysBone Constraint コンポーネントを設定します。


### PR DESCRIPTION
## Summary

This PR implements `VRMC_springBone_limit`.

## Details

This is implemented based on the draft specification at the following point: https://github.com/vrm-c/vrm-specification/pull/496/changes/75fbd48a7cb1d7250fa955838af6140e9c84844c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental "Enable Spring Bone Limit Extension" option to apply angle-limit constraints on spring bones. Requires application support for the VRMC_springBone_limit extension.

* **Documentation**
  * Updated spring bone conversion documentation explaining the new experimental limit extension feature and its compatibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->