### PR TITLE
[export] Change to manage `BlendshapeSelectWindow` internally

### DIFF
--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -13,6 +13,7 @@ using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using com.github.hkrn.ui;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
@@ -24,7 +25,6 @@ using Object = UnityEngine.Object;
 
 #if NVE_HAS_VRCHAT_AVATAR_SDK
 using System.Net.Http;
-using System.Reflection;
 using System.Threading;
 using VRC.Core;
 using VRC.Dynamics;
@@ -1227,40 +1227,16 @@ namespace com.github.hkrn
 #if NVE_HAS_MODULAR_AVATAR
                     if (GUI.Button(fieldRect, "Select"))
                     {
-                        const BindingFlags bindingAttrPrivate = BindingFlags.NonPublic | BindingFlags.Instance;
-                        var assembly = typeof(nadena.dev.modular_avatar.core.editor.AvatarProcessor).Assembly;
-                        var blendShapeSelectWindow =
-                            assembly.GetType("nadena.dev.modular_avatar.core.editor.BlendshapeSelectWindow");
-                        if (blendShapeSelectWindow == null)
-                        {
-                            EditorUtility.DisplayDialog("Select button is unavailable",
-                                "Select button is unavailable due to BlendshapeSelectWindow is unavailable", "OK");
-                            Debug.LogWarning("BlendshapeSelectWindow is unavailable and will be skipped");
-                            break;
-                        }
-
-                        var avatarRoot = blendShapeSelectWindow.GetField("AvatarRoot", bindingAttrPrivate);
-                        var offerBinding = blendShapeSelectWindow.GetField("OfferBinding", bindingAttrPrivate);
-                        var show = blendShapeSelectWindow.GetMethod("Show", new Type[] { });
-                        if (avatarRoot == null || offerBinding == null || show == null)
-                        {
-                            EditorUtility.DisplayDialog("Select button is unavailable",
-                                "Select button is unavailable due to BlendshapeSelectWindow API is changed", "OK");
-                            Debug.LogWarning("BlendshapeSelectWindow API is changed and will be skipped");
-                            break;
-                        }
-
                         if (_window)
                         {
                             Object.DestroyImmediate(_window);
                             _window = null;
                         }
 
-                        _window = ScriptableObject.CreateInstance(blendShapeSelectWindow);
-                        avatarRoot.SetValue(_window, gameObject);
-                        offerBinding.SetValue(_window,
-                            (Action<nadena.dev.modular_avatar.core.BlendshapeBinding>)OfferBinding);
-                        show.Invoke(_window, null);
+                        _window = ScriptableObject.CreateInstance<BlendshapeSelectWindow>();
+                        _window.AvatarRoot = gameObject;
+                        _window.OfferBinding = OfferBinding;
+                        _window.Show();
 
                         void OfferBinding(nadena.dev.modular_avatar.core.BlendshapeBinding binding)
                         {
@@ -1383,7 +1359,7 @@ namespace com.github.hkrn
         private static float LineHeight => EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
 
         private List<string> _blendShapeNames = new();
-        private ScriptableObject? _window;
+        private BlendshapeSelectWindow? _window;
         private int _lastTransformInstanceId;
     }
 

--- a/Editor/NDMFVRMExporter.cs
+++ b/Editor/NDMFVRMExporter.cs
@@ -13,7 +13,6 @@ using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using com.github.hkrn.ui;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
@@ -1233,10 +1232,11 @@ namespace com.github.hkrn
                             _window = null;
                         }
 
-                        _window = ScriptableObject.CreateInstance<BlendshapeSelectWindow>();
-                        _window.AvatarRoot = gameObject;
-                        _window.OfferBinding = OfferBinding;
-                        _window.Show();
+                        var window = ScriptableObject.CreateInstance<ui.BlendshapeSelectWindow>();
+                        window.AvatarRoot = gameObject;
+                        window.OfferBinding = OfferBinding;
+                        window.Show();
+                        _window = window;
 
                         void OfferBinding(nadena.dev.modular_avatar.core.BlendshapeBinding binding)
                         {
@@ -1359,7 +1359,7 @@ namespace com.github.hkrn
         private static float LineHeight => EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
 
         private List<string> _blendShapeNames = new();
-        private BlendshapeSelectWindow? _window;
+        private ScriptableObject? _window;
         private int _lastTransformInstanceId;
     }
 

--- a/Editor/UI/BlendshapeSelectWindow.cs
+++ b/Editor/UI/BlendshapeSelectWindow.cs
@@ -1,0 +1,321 @@
+// from Modular Avatar 1.17.1 without localization
+// https://github.com/bdunderscore/modular-avatar/blob/17a2456c1dbf7cffd5257b46a0ca7a6659f00e9b/Editor/Inspector/BlendshapeSelectTreeView.cs
+#if NVE_HAS_MODULAR_AVATAR
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using nadena.dev.modular_avatar.core;
+using nadena.dev.ndmf.runtime;
+using UnityEditor;
+using UnityEditor.IMGUI.Controls;
+using UnityEngine;
+
+namespace com.github.hkrn.ui
+{
+    internal class BlendshapeSelectWindow : EditorWindow
+    {
+        internal GameObject? AvatarRoot;
+        internal Mesh? SingleMesh;
+        private BlendshapeTree? _tree;
+
+        internal SearchField? _searchField;
+        internal Action<BlendshapeBinding>? OfferBinding;
+        internal Action<BlendshapeBinding>? OfferSingleClick;
+        internal Action<IList<BlendshapeBinding>>? OfferMultipleBindings;
+
+        private void Awake()
+        {
+            titleContent = new GUIContent("Select blendshapes");
+        }
+
+        private void OnLostFocus()
+        {
+            Close();
+        }
+
+        void OnGUI()
+        {
+            var rect = new Rect(0, 0, position.width, position.height);
+
+            if (_tree == null)
+            {
+                _searchField = new SearchField();
+                if (SingleMesh != null)
+                {
+                    _tree = new BlendshapeTree(SingleMesh, new TreeViewState());
+                } else if (AvatarRoot != null) {
+                    _tree = new BlendshapeTree(AvatarRoot, new TreeViewState());
+                }
+                else
+                {
+                    Close();
+                }
+                _tree.OfferBinding = (binding) => OfferBinding?.Invoke(binding);
+                _tree.OfferSingleClick = binding => OfferSingleClick?.Invoke(binding);
+                _tree.OfferMultipleBindings = bindings => OfferMultipleBindings?.Invoke(bindings);
+                _tree.Reload();
+
+                _tree.SetExpanded(0, true);
+            }
+
+            var sfRect = GUILayoutUtility.GetRect(1, 99999, EditorGUIUtility.singleLineHeight,
+                EditorGUIUtility.singleLineHeight, GUILayout.ExpandWidth(true));
+            _tree.searchString = _searchField!.OnGUI(sfRect, _tree.searchString);
+
+            var remaining = GUILayoutUtility.GetRect(1, 99999, EditorGUIUtility.singleLineHeight * 2, 99999999,
+                GUILayout.ExpandWidth(true), GUILayout.ExpandHeight(true));
+            _tree.OnGUI(remaining);
+
+            var selectedCount = _tree.GetSelectedBindings().Count;
+            using (new EditorGUI.DisabledScope(selectedCount < 1))
+            {
+                // if (GUILayout.Button(Localization.S_f("blendshape.add_selected", selectedCount.ToString())))
+                if (GUILayout.Button(string.Format("Add {0} Selected", selectedCount.ToString())))
+                {
+                    var bindings = _tree.GetSelectedBindings();
+                    if (bindings.Count > 0)
+                    {
+                        OfferMultipleBindings?.Invoke(bindings);
+                    }
+                }
+            }
+        }
+    }
+
+    internal class BlendshapeTree : TreeView
+    {
+        internal class OfferItem : TreeViewItem
+        {
+            // Initialized when the item is created in CreateBlendshapes()
+            public BlendshapeBinding binding = default!;
+        }
+
+        private readonly Mesh? _singleMesh;
+        private readonly GameObject? _avatarRoot;
+        // Initialized in BuildRoot() which is called by Unity TreeView before any access
+        private List<BlendshapeBinding?> _candidateBindings = null!;
+
+        // Set by caller after construction (see BlendshapeSelectWindow.OnGUI)
+        internal Action<BlendshapeBinding> OfferBinding = null!;
+        internal Action<BlendshapeBinding>? OfferSingleClick;
+        internal Action<IList<BlendshapeBinding>>? OfferMultipleBindings;
+
+        public BlendshapeTree(GameObject avatarRoot, TreeViewState state) : base(state)
+        {
+            this._avatarRoot = avatarRoot;
+        }
+
+        public BlendshapeTree(Mesh mesh, TreeViewState state) : base(state)
+        {
+            this._singleMesh = mesh;
+        }
+
+        public BlendshapeTree(GameObject avatarRoot, TreeViewState state, MultiColumnHeader multiColumnHeader) : base(
+            state, multiColumnHeader)
+        {
+            this._avatarRoot = avatarRoot;
+        }
+
+        protected override void RowGUI(RowGUIArgs args)
+        {
+            if (!string.IsNullOrEmpty(searchString) && args.item is OfferItem offer)
+            {
+                var rect = args.rowRect;
+
+                var binding = offer.binding;
+                string objName;
+                if (binding.ReferenceMesh == null)
+                {
+                    objName = "";
+                }
+                else
+                {
+                    objName = binding.ReferenceMesh.referencePath;
+                    var index = objName.LastIndexOf('/');
+                    if (index >= 0) objName = objName.Substring(index + 1);
+
+                    objName += " / ";
+                }
+
+                var content = new GUIContent(objName);
+
+                var width = EditorStyles.label.CalcSize(content).x;
+                var color = GUI.color;
+
+                var grey = color;
+                grey.a *= 0.7f;
+                GUI.color = grey;
+
+                EditorGUI.LabelField(rect, content);
+
+                GUI.color = color;
+
+                rect.x += width;
+                rect.width -= width;
+
+                if (rect.width >= 0)
+                {
+                    EditorGUI.LabelField(rect, binding.Blendshape);
+                }
+            }
+            else
+            {
+                base.RowGUI(args);
+            }
+        }
+
+        protected override bool CanMultiSelect(TreeViewItem item)
+        {
+            return item is OfferItem;
+        }
+
+        internal IList<BlendshapeBinding> GetSelectedBindings()
+        {
+            var bindings = new List<BlendshapeBinding>();
+            foreach (var id in GetSelection())
+            {
+                if (id >= 0 && id < _candidateBindings.Count && _candidateBindings[id].HasValue)
+                {
+                    bindings.Add(_candidateBindings[id]!.Value);
+                }
+            }
+            return bindings;
+        }
+
+        protected override void KeyEvent()
+        {
+            if (Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Return)
+            {
+                var bindings = GetSelectedBindings();
+                if (bindings.Count > 0)
+                {
+                    OfferMultipleBindings?.Invoke(bindings);
+                    Event.current.Use();
+                    return;
+                }
+            }
+
+            base.KeyEvent();
+        }
+
+        protected override void SingleClickedItem(int id)
+        {
+            var binding = _candidateBindings[id];
+            if (binding.HasValue)
+            {
+                OfferSingleClick?.Invoke(binding.Value);
+            }
+        }
+
+        protected override void DoubleClickedItem(int id)
+        {
+            var binding = _candidateBindings[id];
+            if (binding.HasValue)
+            {
+                OfferBinding.Invoke(binding.Value);
+            }
+        }
+
+        protected override TreeViewItem BuildRoot()
+        {
+            var root = new TreeViewItem {id = 0, depth = -1, displayName = "Root"};
+            _candidateBindings = new List<BlendshapeBinding?>();
+            _candidateBindings.Add(null);
+
+            var allItems = new List<TreeViewItem>();
+
+            int createdDepth = 0;
+            List<string> ObjectDisplayNames = new List<string>();
+
+            if (_avatarRoot != null)
+            {
+                WalkTree(_avatarRoot, allItems, ObjectDisplayNames, ref createdDepth);
+            }
+            else
+            {
+                CreateBlendshapes(allItems, _singleMesh!, null, 0);
+            }
+
+            SetupParentsAndChildrenFromDepths(root, allItems);
+
+            return root;
+        }
+
+        private void WalkTree(GameObject node, List<TreeViewItem> items, List<string> objectDisplayNames,
+            ref int createdDepth)
+        {
+            objectDisplayNames.Add(node.name);
+
+            var smr = node.GetComponent<SkinnedMeshRenderer>();
+            if (smr != null && smr.sharedMesh != null && smr.sharedMesh.blendShapeCount > 0)
+            {
+                while (createdDepth < objectDisplayNames.Count)
+                {
+                    items.Add(new TreeViewItem
+                    {
+                        id = _candidateBindings.Count, depth = createdDepth,
+                        displayName = objectDisplayNames[createdDepth]
+                    });
+                    _candidateBindings.Add(null);
+                    createdDepth++;
+                }
+
+                CreateBlendshapes(smr, items, ref createdDepth);
+            }
+
+            foreach (Transform child in node.transform)
+            {
+                WalkTree(child.gameObject, items, objectDisplayNames, ref createdDepth);
+            }
+
+            objectDisplayNames.RemoveAt(objectDisplayNames.Count - 1);
+            createdDepth = Math.Min(createdDepth, objectDisplayNames.Count);
+        }
+
+        private void CreateBlendshapes(SkinnedMeshRenderer smr, List<TreeViewItem> items, ref int createdDepth)
+        {
+            items.Add(new TreeViewItem
+                {id = _candidateBindings.Count, depth = createdDepth, displayName = "BlendShapes"});
+            _candidateBindings.Add(null);
+            createdDepth++;
+
+            var path = RuntimeUtil.RelativePath(_avatarRoot, smr.gameObject);
+            var mesh = smr.sharedMesh;
+
+            CreateBlendshapes(items, mesh, path, createdDepth);
+
+            createdDepth--;
+        }
+
+        private void CreateBlendshapes(List<TreeViewItem> items, Mesh mesh, string? path, int createdDepth)
+        {
+            List<BlendshapeBinding> bindings = Enumerable.Range(0, mesh.blendShapeCount)
+                .Select(n =>
+                {
+                    var name = mesh.GetBlendShapeName(n);
+                    return new BlendshapeBinding()
+                    {
+                        Blendshape = name,
+                        ReferenceMesh = path == null ? null : new AvatarObjectReference()
+                        {
+                            referencePath = path
+                        }
+                    };
+                })
+                .ToList();
+
+            foreach (var binding in bindings)
+            {
+                items.Add(new OfferItem
+                {
+                    id = _candidateBindings.Count, depth = createdDepth, displayName = binding.Blendshape,
+                    binding = binding
+                });
+                _candidateBindings.Add(binding);
+            }
+        }
+    }
+}
+#endif // NVE_HAS_MODULAR_AVATAR

--- a/Editor/UI/BlendshapeSelectWindow.cs.meta
+++ b/Editor/UI/BlendshapeSelectWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01a9a7df975d14ffb9616f8c8286dc34
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

This PR change to manage `BlendshapeSelectWindow` internally.

@coderabbitai ignore

## Details

GH-148 was retrieving `BlendshapeSelectWindow` via reflection, but based on the outcome of https://github.com/bdunderscore/modular-avatar/issues/1993, changed policy to fork and manage internally. While this removes the need for reflection, it still depends on Modular Avatar's implementation, so Modular Avatar remains required.

Fixes https://github.com/bdunderscore/modular-avatar/issues/1993