### PR TITLE
[exporter] Fix bug where BlinkL/BlinkR are not set

### DIFF
--- a/Editor/NdmfVrmExporterPlugin.cs
+++ b/Editor/NdmfVrmExporterPlugin.cs
@@ -242,7 +242,7 @@ namespace com.github.hkrn
             {
                 return;
             }
-            
+
             variants.Add(new MaterialVariant
             {
                 Name = !string.IsNullOrEmpty(name) ? $"{name}/{variantName}" : variantName,
@@ -549,6 +549,10 @@ namespace com.github.hkrn
                 allExpressionUsedBlendShapeNames.AddRange(component.expressionPresetSadBlendShape.BlendShapeNames);
                 allExpressionUsedBlendShapeNames.AddRange(component.expressionPresetRelaxedBlendShape.BlendShapeNames);
                 allExpressionUsedBlendShapeNames.AddRange(component.expressionPresetSurprisedBlendShape
+                    .BlendShapeNames);
+                allExpressionUsedBlendShapeNames.AddRange(component.expressionPresetBlinkLeftBlendShape
+                    .BlendShapeNames);
+                allExpressionUsedBlendShapeNames.AddRange(component.expressionPresetBlinkRightBlendShape
                     .BlendShapeNames);
                 foreach (var property in component.expressionCustomBlendShapes)
                 {


### PR DESCRIPTION
## Summary

This PR fixes a bug where BlinkL/BlinkR are not set.

@coderabbitai ignore

## Details

When using AAO's Trace and Optimize component, BlinkL/BlinkR expressions were being removed by AAO due to missing optimization suppression, causing them not to be set in the exported VRM. Fix by explicitly specifying optimization suppression to ensure they are set correctly.